### PR TITLE
Group forecast by condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/**]
   pull_request:
     branches: [main]
 
@@ -38,3 +38,9 @@ jobs:
 
       - name: Test
         run: pnpm run test
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weather-forecast-card-${{ github.sha }}
+          path: dist/weather-forecast-card.js
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ dist
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/node,macos,visualstudiocode
+src/components/git.code-workspace

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ The `current` object controls the display of current weather information and att
 | `mode`                  | string  | `simple` | Forecast display mode. `simple`: Horizontal scrollable list of forecast entries. `chart`: Visualize temperature and precipitation trends on a line/bar chart.                                                                                                                         |
 | `scroll_to_selected`    | boolean | `false`  | Automatically scrolls to the first hourly forecast of the selected date when switching to hourly view, and returns to the first daily entry when switching back.                                                                                                                      |
 | `show_sun_times`        | boolean | `true`   | Displays sunrise and sunset times in the hourly forecast, and uses specific icons to visualize clear night conditions.                                                                                                                                                                |
+| `group_condition_icons` | boolean | `false`  | Group consecutive forecast entries that share the same visual condition into a single span with one icon. Improves readability by avoiding repeated icons when conditions remain unchanged across hours.                                     |
+| `condition_colors`      | boolean | `true`   | Colorize forecast condition spans with condition-based background colors. Defaults are provided; you can override per condition via `condition_color_map`.                                                                                      |
+| `condition_color_map`   | object  | optional | Optional map to override condition colors. Keys are condition names (lower-case, dashes, e.g., `clear-night`, `lightning-rainy`) and values can be a string (background) or an object `{ background, foreground }`.                            |
 | `temperature_precision` | number  | optional | Number of decimal places to display for temperature values (0-2). Applies to forecast temperatures shown in `chart` mode. Due to the layout limitations, this setting is not affecting `simple` mode which uses fixed precision of `0`.                                               |
 | `use_color_thresholds`  | boolean | `false`  | Replaces solid temperature lines with a gradient based on actual values when using forecast chart mode. Colors transition at fixed intervals: -10° (Cold), 0° (Freezing), 8° (Chilly), 18° (Mild), 26° (Warm), and 34° (Hot). These thresholds are specified in degrees Celsius (°C). |
 
@@ -156,6 +159,37 @@ forecast:
   mode: chart
   extra_attribute: wind_direction
 ```
+
+## Condition Colors
+
+When `forecast.condition_colors` is enabled, the card colors the background of grouped condition spans to visually convey weather changes across time. Colors default to sensible values, and can be customized per condition using `forecast.condition_color_map`.
+
+Notes:
+- Keys are normalized condition names: lower-case with `-` separators (e.g., `clear-night`, `lightning-rainy`, `partlycloudy`).
+- A value can be a background color string (e.g., `"#44739d"`) or an object with `background` and optional `foreground`.
+- If `forecast.show_sun_times` is enabled, daytime-only conditions at night (e.g., `sunny` before sunrise) are treated as `clear-night` for coloring and grouping.
+
+### Example: Customizing condition colors
+
+```yaml
+type: custom:weather-forecast-card
+entity: weather.home
+forecast:
+  group_condition_icons: true
+  condition_colors: true
+  condition_color_map:
+    clear-night: "#000000"           # deep night sky
+    sunny:
+      background: "#ffd166"         # warm sunny day
+      foreground: "#000000"         # dark icon for contrast
+    partlycloudy: "#b3dbff"         # light blue
+    rainy: "#44739d"                # classic rainy blue
+    lightning-rainy:
+      background: "#374151"         # stormy gray
+      foreground: "#fbbf24"         # highlight lightning
+```
+
+With grouping enabled, the card renders a single icon and a colored span across consecutive hours sharing the same visual condition, improving scanability of changing weather.
 
 ## Weather Condition Effects
 

--- a/src/components/wfc-forecast-header-items.ts
+++ b/src/components/wfc-forecast-header-items.ts
@@ -27,6 +27,8 @@ export class WfcForecastHeaderItems extends LitElement {
   @property({ attribute: false }) forecast!: ForecastAttribute;
   @property({ attribute: false }) forecastType!: ForecastType;
   @property({ attribute: false }) config!: WeatherForecastCardConfig;
+  @property({ attribute: false }) hideTime: boolean = false;
+  @property({ attribute: false }) hideIcon: boolean = false;
 
   private suntimesInfo?: SuntimesInfo | null;
 
@@ -62,15 +64,19 @@ export class WfcForecastHeaderItems extends LitElement {
         : false;
 
     return html`
-      <div class="wfc-forecast-slot-time wfc-label ${className || ""}">
-        ${label}
-      </div>
-      <wfc-weather-condition-icon-provider
-        .hass=${this.hass}
-        .config=${this.config}
-        .state=${this.forecast.condition}
-        .isNightTime=${isNightTime}
-      ></wfc-weather-condition-icon-provider>
+      ${!this.hideTime ? html`
+        <div class="wfc-forecast-slot-time wfc-label ${className || ""}">
+          ${label}
+        </div>
+      ` : nothing}
+      ${!this.hideIcon ? html`
+        <wfc-weather-condition-icon-provider
+          .hass=${this.hass}
+          .config=${this.config}
+          .state=${this.forecast.condition}
+          .isNightTime=${isNightTime}
+        ></wfc-weather-condition-icon-provider>
+      ` : nothing}
     `;
   }
 

--- a/src/components/wfc-forecast-simple.ts
+++ b/src/components/wfc-forecast-simple.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { ActionHandlerEvent, fireEvent } from "custom-card-helpers";
 import { actionHandler } from "../hass";
 import { DragScrollController } from "../controllers/drag-scroll-controller";
@@ -8,7 +9,8 @@ import {
   ForecastActionDetails,
   WeatherForecastCardConfig,
 } from "../types";
-import { formatDay } from "../helpers";
+import { formatDay, getSuntimesInfo, groupForecastByCondition, getLocalizedConditionName } from "../helpers";
+import { getConditionColorNightAware, getContrastingTextColor } from "../data/condition-colors";
 import {
   ForecastAttribute,
   ForecastType,
@@ -38,12 +40,12 @@ export class WfcForecastSimple extends LitElement {
   protected createRenderRoot() {
     return this;
   }
-
   render(): TemplateResult | typeof nothing {
     if (!this.forecast?.length) {
       return nothing;
     }
 
+    const useGroupedIcons = this.config.forecast?.group_condition_icons ?? false;
     const forecastTemplates: TemplateResult[] = [];
     const maxPrecipitation = getMaxPrecipitationForUnit(
       getWeatherUnit(this.hass, this.weatherEntity, "precipitation"),
@@ -52,46 +54,184 @@ export class WfcForecastSimple extends LitElement {
 
     let currentDay: string | undefined;
 
-    this.forecast.forEach((forecast, index) => {
-      if (!forecast.datetime) {
-        return;
-      }
+    if (useGroupedIcons) {
+      const timeRow: TemplateResult[] = [];
+      const spanRow: TemplateResult[] = [];
+      const detailRow: TemplateResult[] = [];
+      const conditionSpans = groupForecastByCondition(this.forecast, this.hass);
 
-      if (this.forecastType === "hourly") {
-        const forecastDay = formatDay(this.hass, forecast.datetime);
-        if (currentDay !== forecastDay) {
-          currentDay = forecastDay;
-          forecastTemplates.push(
-            html`<div class="wfc-day-indicator-container">
-              <div class="wfc-day-indicator wfc-label">${forecastDay}</div>
-            </div>`
-          );
+      this.forecast.forEach((forecast, index) => {
+        if (!forecast.datetime) {
+          return;
         }
-      }
 
-      forecastTemplates.push(html`
-        <div class="wfc-forecast-slot" data-index=${index}>
-          <wfc-forecast-header-items
-            .hass=${this.hass}
-            .forecast=${forecast}
-            .forecastType=${this.forecastType}
-            .config=${this.config}
-          ></wfc-forecast-header-items>
-          <wfc-forecast-details
-            .hass=${this.hass}
-            .forecast=${forecast}
-            .maxPrecipitation=${maxPrecipitation}
-            .config=${this.config}
-          ></wfc-forecast-details>
-          <wfc-forecast-info
-            .hass=${this.hass}
-            .weatherEntity=${this.weatherEntity}
-            .forecast=${forecast}
-            .config=${this.config}
-          ></wfc-forecast-info>
+        // Check for day change and add day indicator
+        if (this.forecastType === "hourly") {
+          const forecastDay = formatDay(this.hass, forecast.datetime);
+          if (currentDay !== forecastDay) {
+            currentDay = forecastDay;
+            timeRow.push(
+              html`<div class="wfc-day-indicator-container">
+                <div class="wfc-day-indicator wfc-label">${forecastDay}</div>
+              </div>`
+            );
+          }
+        }
+
+        // Time labels only
+        timeRow.push(html`
+          <div class="wfc-forecast-slot" data-index=${index}>
+            <wfc-forecast-header-items
+              .hass=${this.hass}
+              .forecast=${forecast}
+              .forecastType=${this.forecastType}
+              .config=${this.config}
+              .hideIcon=${true}
+              .hideTime=${false}
+            ></wfc-forecast-header-items>
+          </div>
+        `);
+
+        // Condition spans
+        const conditionSpan = conditionSpans.find(span => span.startIndex === index);
+        if (conditionSpan) {
+          // Get background color for this condition
+          const useColors = this.config.forecast?.condition_colors ?? true;
+          const isNightTime =
+            this.forecastType === "hourly" &&
+            this.config.forecast?.show_sun_times
+              ? getSuntimesInfo(this.hass, forecast.datetime)?.isNightTime ?? false
+              : false;
+
+          const colors = useColors
+            ? getConditionColorNightAware(
+                forecast.condition,
+                isNightTime,
+                this.config.forecast?.condition_color_map
+              )
+            : {};
+          const bgStyle = colors.background ? `background-color: ${colors.background};` : '';
+          const textColor = colors.background ? getContrastingTextColor(colors.background) : '';
+          const fgStyle = textColor ? `color: ${textColor};` : '';
+          const showLabels = this.config.forecast?.show_condition_labels ?? false;
+          const conditionLabel = showLabels ? getLocalizedConditionName(this.hass, forecast.condition || '') : '';
+          
+          spanRow.push(html`
+            <div 
+              class="wfc-forecast-condition-span" 
+              style="grid-column: span ${conditionSpan.count}; ${bgStyle}"
+            >
+              <div class="wfc-condition-icon-sticky">
+                <wfc-forecast-header-items
+                  .hass=${this.hass}
+                  .forecast=${forecast}
+                  .forecastType=${this.forecastType}
+                  .config=${this.config}
+                  .hideTime=${true}
+                  .hideIcon=${false}
+                ></wfc-forecast-header-items>
+                ${showLabels && conditionLabel ? html`
+                  <span class="wfc-condition-label" style="${fgStyle}">${conditionLabel}</span>
+                ` : nothing}
+              </div>
+            </div>
+          `);
+        }
+
+        // Details and info per slot
+        detailRow.push(html`
+          <div class="wfc-forecast-slot" data-index=${index}>
+            <wfc-forecast-details
+              .hass=${this.hass}
+              .forecast=${forecast}
+              .maxPrecipitation=${maxPrecipitation}
+              .config=${this.config}
+            ></wfc-forecast-details>
+            <wfc-forecast-info
+              .hass=${this.hass}
+              .weatherEntity=${this.weatherEntity}
+              .forecast=${forecast}
+              .config=${this.config}
+            ></wfc-forecast-info>
+          </div>
+        `);
+      });
+
+      const count = this.forecast.length;
+      const gaps = Math.max(count - 1, 0);
+      const totalWidthCalc = `calc(${count} * var(--forecast-item-width) + ${gaps} * var(--forecast-item-gap))`;
+
+      const scrollContainerStyle = {
+        "--wfc-forecast-chart-width": totalWidthCalc,
+      };
+
+      return html`
+        <div
+          class="wfc-forecast wfc-scroll-container"
+          style=${styleMap(scrollContainerStyle)}
+          .actionHandler=${actionHandler({
+            hasHold: this.config.forecast_action?.hold_action !== undefined,
+            hasDoubleClick:
+              this.config.forecast_action?.double_tap_action !== undefined,
+            stopPropagation: true,
+          })}
+          @action=${this._onForecastAction}
+          @pointerdown=${this._onPointerDown}
+        >
+          <div class="wfc-forecast-grouped-wrapper">
+            <div class="wfc-forecast-time-row">${timeRow}</div>
+            <div 
+              class="wfc-forecast-span-row"
+              style="grid-template-columns: repeat(${this.forecast.length}, var(--forecast-item-width));"
+            >
+              ${spanRow}
+            </div>
+            <div class="wfc-forecast-row">${detailRow}</div>
+          </div>
         </div>
-      `);
-    });
+      `;
+    } else {
+      this.forecast.forEach((forecast, index) => {
+        if (!forecast.datetime) {
+          return;
+        }
+
+        if (this.forecastType === "hourly") {
+          const forecastDay = formatDay(this.hass, forecast.datetime);
+          if (currentDay !== forecastDay) {
+            currentDay = forecastDay;
+            forecastTemplates.push(
+              html`<div class="wfc-day-indicator-container">
+                <div class="wfc-day-indicator wfc-label">${forecastDay}</div>
+              </div>`
+            );
+          }
+        }
+
+        forecastTemplates.push(html`
+          <div class="wfc-forecast-slot" data-index=${index}>
+            <wfc-forecast-header-items
+              .hass=${this.hass}
+              .forecast=${forecast}
+              .forecastType=${this.forecastType}
+              .config=${this.config}
+            ></wfc-forecast-header-items>
+            <wfc-forecast-details
+              .hass=${this.hass}
+              .forecast=${forecast}
+              .maxPrecipitation=${maxPrecipitation}
+              .config=${this.config}
+            ></wfc-forecast-details>
+            <wfc-forecast-info
+              .hass=${this.hass}
+              .weatherEntity=${this.weatherEntity}
+              .forecast=${forecast}
+              .config=${this.config}
+            ></wfc-forecast-info>
+          </div>
+        `);
+      });
+    }
 
     return html`
       <div

--- a/src/data/condition-colors.ts
+++ b/src/data/condition-colors.ts
@@ -1,0 +1,136 @@
+import { ConditionColorMap } from "../types";
+
+/**
+ * Calculate relative luminance of a color (WCAG formula)
+ * Returns a value between 0 (black) and 1 (white)
+ */
+function getRelativeLuminance(hexColor: string): number {
+  // Remove # if present
+  let hex = hexColor.replace('#', '');
+  
+  // Expand 3-digit hex to 6-digit
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+  
+  // Parse RGB values
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+  
+  // Apply gamma correction
+  const rsRGB = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+  const gsRGB = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+  const bsRGB = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+  
+  // Calculate luminance
+  return 0.2126 * rsRGB + 0.7152 * gsRGB + 0.0722 * bsRGB;
+}
+
+/**
+ * Get contrasting text color (black or white) for a given background color
+ * Uses WCAG relative luminance to ensure readability
+ */
+export function getContrastingTextColor(backgroundColor: string): string {
+  const luminance = getRelativeLuminance(backgroundColor);
+  // Use white text for dark backgrounds (luminance < 0.5), black for light backgrounds
+  return luminance < 0.5 ? '#ffffff' : '#000000';
+}
+
+/**
+ * Default condition colors based on hourly-weather card.
+ * These represent the color of the sky/weather condition.
+ */
+export const DEFAULT_CONDITION_COLORS: ConditionColorMap = {
+  "clear-night": "#000",
+  cloudy: "#777",
+  fog: "#777", // same as cloudy
+  hail: "#2b5174",
+  lightning: "#44739d", // same as rainy
+  "lightning-rainy": "#44739d", // same as rainy
+  partlycloudy: "#b3dbff",
+  pouring: "#44739d", // same as rainy
+  rainy: "#44739d",
+  snowy: "#fff",
+  "snowy-rainy": "#b3dbff", // same as partlycloudy
+  sunny: "#90cbff",
+  windy: "#90cbff", // same as sunny
+  "windy-variant": "#90cbff", // same as sunny
+  exceptional: "#ff9d00",
+};
+
+/**
+ * Gets the color for a weather condition, falling back to defaults
+ * and similar conditions as needed.
+ */
+export function getConditionColor(
+  condition: string,
+  customColors?: ConditionColorMap
+): { foreground?: string; background?: string } {
+  const normalizedCondition = condition.toLowerCase().replace(/_/g, "-");
+
+  // Check custom colors first
+  if (customColors?.[normalizedCondition]) {
+    const color = customColors[normalizedCondition];
+    if (typeof color === "string") {
+      return { background: color };
+    }
+    return color;
+  }
+
+  // Fall back to default
+  const defaultColor = DEFAULT_CONDITION_COLORS[normalizedCondition];
+  if (defaultColor) {
+    return { background: typeof defaultColor === "string" ? defaultColor : defaultColor.background };
+  }
+
+  // No color found
+  return {};
+}
+
+const NIGHT_FALLBACK_CONDITIONS = new Set([
+  "sunny",
+  "clear",
+  "windy",
+  "windy-variant",
+  "partlycloudy",
+  "exceptional",
+]);
+
+const NIGHT_SAFE_CONDITIONS = new Set([
+  "clear-night",
+  "cloudy",
+  "fog",
+  "hail",
+  "lightning",
+  "lightning-rainy",
+  "pouring",
+  "rainy",
+  "snowy",
+  "snowy-rainy",
+]);
+
+const mapConditionForNight = (condition: string, isNightTime: boolean): string => {
+  if (!isNightTime) return condition;
+
+  const normalized = condition.toLowerCase().replace(/_/g, "-");
+
+  if (NIGHT_SAFE_CONDITIONS.has(normalized)) {
+    return normalized;
+  }
+
+  if (NIGHT_FALLBACK_CONDITIONS.has(normalized)) {
+    return "clear-night";
+  }
+
+  return normalized;
+};
+
+export function getConditionColorNightAware(
+  condition: string,
+  isNightTime: boolean,
+  customColors?: ConditionColorMap
+): { foreground?: string; background?: string } {
+  const conditionForColor = mapConditionForNight(condition, isNightTime);
+  return getConditionColor(conditionForColor, customColors);
+}

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -458,12 +458,16 @@ export const aggregateHourlyForecastData = (
   let i = 0;
 
   while (i < forecast.length) {
-    const currentHour = new Date(forecast[i]!.datetime).getHours();
-    const remainder = currentHour % groupSize;
-    const steps = remainder === 0 ? groupSize : groupSize - remainder;
+    const group: ForecastAttribute[] = [];
 
-    const group = forecast.slice(i, i + steps);
-    i += group.length;
+    // Group consecutive entries up to groupSize (condition-based grouping handled later)
+    while (i < forecast.length && group.length < groupSize) {
+      const nextEntry = forecast[i];
+      if (!nextEntry) break;
+
+      group.push(nextEntry);
+      i += 1;
+    }
 
     if (group.length === 0) continue;
     const temperatures = group.map((e) => e.temperature);
@@ -483,13 +487,18 @@ export const aggregateHourlyForecastData = (
       .map((e) => e.precipitation_probability)
       .filter((e): e is number => e !== undefined);
 
-    const lastEntryDate = new Date(group[group.length - 1]!.datetime);
-    lastEntryDate.setMinutes(59);
-    lastEntryDate.setSeconds(59);
+    const lastEntry = group[group.length - 1]!;
+    const lastEntryDate = lastEntry.groupEndtime
+      ? new Date(lastEntry.groupEndtime)
+      : new Date(lastEntry.datetime);
+    const nextEntry = forecast[i];
+    const endDate = nextEntry
+      ? new Date(nextEntry.datetime)
+      : lastEntryDate;
 
     const aggregatedEntry: ForecastAttribute = {
       datetime: group[0]!.datetime,
-      groupEndtime: lastEntryDate.toISOString(),
+      groupEndtime: endDate.toISOString(),
       condition: getWorstCondition(group),
       temperature: parseFloat(average(temperatures).toFixed(1)),
     };

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -19,6 +19,8 @@ import {
   WeatherForecastCardForecastActionConfig,
   WeatherForecastCardForecastConfig,
 } from "../types";
+import en from "../translations/en.json";
+import de from "../translations/de.json";
 
 type HaFormSelector =
   | { entity: { domain?: string; device_class?: string | string[] } }
@@ -61,6 +63,23 @@ type WeatherForecastCardEditorConfig = {
   interactions?: unknown;
   advanced_settings?: unknown;
 } & WeatherForecastCardConfig;
+
+type EditorTranslationKey = keyof typeof en.editor;
+
+const EDITOR_TRANSLATIONS: Record<string, typeof en> = {
+  en,
+  de,
+};
+
+const translateEditor = (
+  key: EditorTranslationKey,
+  hass?: ExtendedHomeAssistant
+): string | undefined => {
+  const language = hass?.locale?.language || hass?.language || "en";
+  const translations = EDITOR_TRANSLATIONS[language]?.editor;
+
+  return translations?.[key] ?? EDITOR_TRANSLATIONS.en.editor[key];
+};
 
 @customElement("weather-forecast-card-editor")
 export class WeatherForecastCardEditor
@@ -278,6 +297,29 @@ export class WeatherForecastCardEditor
         optional: true,
       },
       {
+        name: "forecast.group_condition_icons",
+        selector: { boolean: {} },
+        default: false,
+        optional: true,
+      },
+      {
+        name: "forecast.show_condition_labels",
+        selector: { boolean: {} },
+        default: false,
+        optional: true,
+      },
+      {
+        name: "forecast.condition_colors",
+        selector: { boolean: {} },
+        default: true,
+        optional: true,
+      },
+      {
+        name: "forecast.condition_color_map",
+        selector: { text: {} },
+        optional: true,
+      },
+      {
         name: "forecast.use_color_thresholds",
         selector: { boolean: {} },
         default: false,
@@ -472,6 +514,26 @@ export class WeatherForecastCardEditor
         return "Scroll to selected forecast";
       case "forecast.show_sun_times":
         return "Show sunrise and sunset times";
+      case "forecast.group_condition_icons":
+        return (
+          translateEditor("group_condition_icons", this.hass) ||
+          "Group condition icons"
+        );
+      case "forecast.show_condition_labels":
+        return (
+          translateEditor("show_condition_labels", this.hass) ||
+          "Show condition labels"
+        );
+      case "forecast.condition_colors":
+        return (
+          translateEditor("condition_colors", this.hass) ||
+          "Use condition colors"
+        );
+      case "forecast.condition_color_map":
+        return (
+          translateEditor("condition_color_map", this.hass) ||
+          "Custom condition color map"
+        );
       case "forecast.use_color_thresholds":
         return "Use color thresholds";
       case "forecast.hourly_group_size":
@@ -521,6 +583,26 @@ export class WeatherForecastCardEditor
         return "Automatically scrolls to the first hourly forecast of the selected date when switching to hourly view, and returns to the first daily entry when switching back.";
       case "forecast.show_sun_times":
         return "Displays sunrise and sunset times in the hourly forecast, and uses specific icons to visualize clear night conditions.";
+      case "forecast.group_condition_icons":
+        return (
+          translateEditor("group_condition_icons_helper", this.hass) ||
+          "Use grouped condition icons when multiple entries share the same visual condition."
+        );
+      case "forecast.show_condition_labels":
+        return (
+          translateEditor("show_condition_labels_helper", this.hass) ||
+          "Display weather condition names next to icons in grouped mode. Labels are hidden if there is insufficient space."
+        );
+      case "forecast.condition_colors":
+        return (
+          translateEditor("condition_colors_helper", this.hass) ||
+          "Enable condition-based background and icon coloring."
+        );
+      case "forecast.condition_color_map":
+        return (
+          translateEditor("condition_color_map_helper", this.hass) ||
+          "Optional JSON map to override foreground/background colors by condition key."
+        );
       case "forecast.use_color_thresholds":
         return "Replaces solid temperature lines with a gradient based on actual values when using forecast chart mode.";
       case "forecast.hourly_group_size":

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,41 @@ import { HomeAssistant, TimeFormat } from "custom-card-helpers";
 import { STATE_NOT_RUNNING } from "home-assistant-js-websocket";
 import * as SunCalc from "suncalc";
 import memoizeOne from "memoize-one";
-import { SuntimesInfo } from "./types";
+import { ConditionSpan, ExtendedHomeAssistant, SuntimesInfo } from "./types";
+import { ForecastAttribute } from "./data/weather";
+
+/**
+ * Get localized weather condition name
+ */
+export const getLocalizedConditionName = (
+  hass: ExtendedHomeAssistant,
+  condition: string
+): string => {
+  const normalizedCondition = condition.toLowerCase().replace(/_/g, "-");
+  return (
+    hass.localize(`component.weather.entity_component._.state.${normalizedCondition}`) ||
+    condition
+  );
+};
+
+// Map condition to night-aware version for grouping
+const mapConditionForNight = (condition: string, isNightTime: boolean): string => {
+  if (!isNightTime) return condition;
+  const normalized = condition.toLowerCase().replace(/_/g, "-");
+  
+  const NIGHT_SAFE_CONDITIONS = new Set([
+    "clear-night", "cloudy", "fog", "hail", "lightning", "lightning-rainy",
+    "pouring", "rainy", "snowy", "snowy-rainy"
+  ]);
+  
+  const NIGHT_FALLBACK_CONDITIONS = new Set([
+    "sunny", "clear", "windy", "windy-variant", "partlycloudy", "exceptional"
+  ]);
+  
+  if (NIGHT_SAFE_CONDITIONS.has(normalized)) return normalized;
+  if (NIGHT_FALLBACK_CONDITIONS.has(normalized)) return "clear-night";
+  return normalized;
+};
 
 export const createWarningText = (
   hass: HomeAssistant | undefined,
@@ -114,4 +148,61 @@ export const endOfHour = (input: Date | string): Date => {
   d.setMinutes(59, 59, 999);
 
   return d;
+};
+
+/**
+ * Groups consecutive forecast items with the same weather condition.
+ * Similar to the lovelace-hourly-weather card's condition grouping.
+ *
+ * @param forecast - Array of forecast items to group
+ * @returns Array of condition spans with start/end indices and counts
+ */
+export const groupForecastByCondition = (
+  forecast: ForecastAttribute[],
+  hass?: HomeAssistant
+): ConditionSpan[] => {
+  if (!forecast || forecast.length === 0) {
+    return [];
+  }
+
+  const conditionSpans: ConditionSpan[] = [];
+  let currentCondition = forecast[0]?.condition || "";
+  let startIndex = 0;
+  let currentIsNight = hass ? getSuntimesInfo(hass, forecast[0].datetime)?.isNightTime : false;
+  let currentNightAwareCondition = mapConditionForNight(currentCondition, currentIsNight);
+
+  for (let i = 1; i < forecast.length; i++) {
+    const condition = forecast[i]?.condition || "";
+    const isNight = hass ? getSuntimesInfo(hass, forecast[i].datetime)?.isNightTime : false;
+    const nightAwareCondition = mapConditionForNight(condition, isNight);
+
+    // Break grouping if NIGHT-AWARE condition changes (visual appearance changes)
+    const conditionChanged = nightAwareCondition !== currentNightAwareCondition;
+
+    if (conditionChanged) {
+      // End of current span, create entry
+      conditionSpans.push({
+        condition: currentCondition,
+        startIndex,
+        endIndex: i - 1,
+        count: i - startIndex,
+      });
+
+      // Start new span
+      currentCondition = condition;
+      currentIsNight = isNight;
+      currentNightAwareCondition = nightAwareCondition;
+      startIndex = i;
+    }
+  }
+
+  // Add the final span
+  conditionSpans.push({
+    condition: currentCondition,
+    startIndex,
+    endIndex: forecast.length - 1,
+    count: forecast.length - startIndex,
+  });
+
+  return conditionSpans;
 };

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -1,0 +1,12 @@
+{
+  "editor": {
+    "group_condition_icons": "Wetter-Icons gruppieren",
+    "group_condition_icons_helper": "Gruppierte Wettersymbole verwenden, wenn mehrere Vorhersageeinträge denselben visuellen Zustand haben.",
+    "show_condition_labels": "Zustandsbeschriftungen anzeigen",
+    "show_condition_labels_helper": "Zeigt Wetterzustandsnamen neben Icons im gruppierten Modus an. Beschriftungen werden ausgeblendet, wenn nicht genügend Platz vorhanden ist.",
+    "condition_colors": "Zustandsfarben verwenden",
+    "condition_colors_helper": "Hintergrund- und Symbolfarben basierend auf dem Wetterzustand aktivieren.",
+    "condition_color_map": "Benutzerdefinierte Zustandsfarbzuordnung",
+    "condition_color_map_helper": "Optionale JSON-Zuordnung, um Vorder- und Hintergrundfarben für bestimmte Bedingungen zu überschreiben."
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,0 +1,12 @@
+{
+  "editor": {
+    "group_condition_icons": "Group condition icons",
+    "group_condition_icons_helper": "Use grouped weather condition icons when multiple forecast entries share the same visual condition.",
+    "show_condition_labels": "Show condition labels",
+    "show_condition_labels_helper": "Display weather condition names next to icons in grouped mode. Labels are hidden if there is insufficient space.",
+    "condition_colors": "Use condition colors",
+    "condition_colors_helper": "Enable condition-based background and icon coloring for forecasts.",
+    "condition_color_map": "Custom condition color map",
+    "condition_color_map_helper": "Optional JSON map to override foreground/background colors for specific conditions."
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,13 @@ export interface ForecastToggleActionConfig extends BaseActionConfig {
   action: "toggle-forecast";
 }
 
+export type ConditionColorValue = string | {
+  foreground?: string;
+  background?: string;
+};
+
+export type ConditionColorMap = Partial<Record<string, ConditionColorValue>>;
+
 export interface WeatherForecastCardForecastConfig {
   extra_attribute?: string;
   mode?: ForecastMode;
@@ -65,6 +72,10 @@ export interface WeatherForecastCardForecastConfig {
   scroll_to_selected?: boolean;
   use_color_thresholds?: boolean;
   temperature_precision?: number;
+  group_condition_icons?: boolean;
+  show_condition_labels?: boolean;
+  condition_colors?: boolean;
+  condition_color_map?: ConditionColorMap;
 }
 
 export interface WeatherForecastCardCurrentConfig {
@@ -123,4 +134,11 @@ export type SuntimesInfo = {
   sunrise: Date;
   sunset: Date;
   isNightTime: boolean;
+};
+
+export type ConditionSpan = {
+  condition: string;
+  startIndex: number;
+  endIndex: number;
+  count: number;
 };

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -312,6 +312,8 @@ ha-card {
   align-items: start;
   position: sticky;
   left: 0px;
+  /* Use top to ensure proper stacking when multiple indicators are sticky */
+  top: 0px;
   z-index: 4;
   pointer-events: none;
   min-width: var(--forecast-item-width);
@@ -319,6 +321,7 @@ ha-card {
   margin-right: calc(
     (var(--forecast-item-width) + var(--forecast-item-gap)) * -1
   );
+  flex-shrink: 0;
 }
 
 .wfc-day-indicator {
@@ -391,6 +394,8 @@ ha-card {
   padding: 2px 0;
   pointer-events: none;
   cursor: grab;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
 }
 
 .wfc-weather-condition-icon-slot .rain {
@@ -477,6 +482,86 @@ ha-card {
   column-gap: var(--forecast-item-gap);
   width: 100% !important;
   min-width: var(--wfc-forecast-chart-width, auto);
+}
+
+/* Shared grouped layout for chart & simple mode */
+.wfc-forecast-grouped-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ha-space-2, 8px);
+  width: 100%;
+}
+
+.wfc-forecast-time-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  column-gap: var(--forecast-item-gap);
+  width: 100%;
+  min-width: var(--wfc-forecast-chart-width, auto);
+}
+
+.wfc-forecast-span-row {
+  display: grid;
+  grid-auto-flow: column dense;
+  grid-auto-columns: var(--forecast-item-width);
+  column-gap: var(--forecast-item-gap);
+  width: 100%;
+  min-width: var(--wfc-forecast-chart-width, auto);
+}
+
+/* Keep detail row aligned in simple mode */
+.wfc-forecast-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  column-gap: var(--forecast-item-gap);
+  width: 100%;
+  min-width: var(--wfc-forecast-chart-width, auto);
+}
+
+
+
+.wfc-forecast-condition-span {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--ha-space-1, 4px);
+  background: color-mix(in srgb, var(--primary-color, #03a9f4) 10%, transparent);
+  border-radius: 8px;
+  padding: var(--ha-space-1, 4px);
+  overflow: visible;
+}
+
+.wfc-condition-icon-sticky {
+  position: sticky;
+  left: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--ha-space-1, 4px);
+  padding-inline-start: var(--ha-space-2, 8px);
+  z-index: 1;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.wfc-condition-icon-sticky > wfc-forecast-header-items {
+  flex-shrink: 0;
+}
+
+.wfc-condition-label {
+  font-size: var(--ha-font-size-m, 14px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-inline-start: var(--ha-space-1, 4px);
+  padding-inline-end: var(--ha-space-1, 4px);
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 wfc-wind-indicator,


### PR DESCRIPTION
This PR introduces the ability to group consecutive forecast entries with the same weather condition, providing a more compact and visually organized forecast display.
Inspired by the [hourly weather card](https://github.com/decompil3d/lovelace-hourly-weather )

<img width="1648" height="938" alt="image" src="https://github.com/user-attachments/assets/dd222b2f-67a8-4d88-8efd-52a5711aeed9" />


- Groups consecutive forecast entries sharing the same weather condition into a single visual span
- Works in both chart mode and simple mode
- Automatically breaks groups at sunrise/sunset transitions to maintain day/night accuracy
- Sticky icons remain visible during horizontal scrolling for better UX

- Adds customizable background colors for each weather condition (e.g., blue for sunny, gray for cloudy)
- Includes sensible defaults based on the hourly-weather card color scheme
- Night-aware color mapping (e.g., "partly cloudy" at night uses "clear-night" color)
- Weather conditon can be displayed per group (optional, translation available

# UI Editor Support

- All new features are configurable directly in the card editor UI
- No YAML editing required for basic configuration
- Added switches for grouped icons, condition colors, and labels
- Added color picker for custom condition color maps
- Technical Changes:

# Configuration Example
```
type: custom:weather-forecast-card
entity: weather.home
forecast:
  mode: simple
  group_condition_icons: true
  condition_colors: true
  show_condition_labels: true
  condition_color_map:
    sunny: '#90cbff'
    partlycloudy: '#b3dbff'
    rainy: '#44739d'
```