### PR TITLE
fix: prevent peak temperature label clipping in daily chart

### DIFF
--- a/src/components/wfc-forecast-chart.ts
+++ b/src/components/wfc-forecast-chart.ts
@@ -85,6 +85,12 @@ const DEFAULT_CHART_FONT_SIZE = 12;
 // Default padding for top and bottom of the chart, used as a baseline for scaling based on font size.
 const DEFAULT_CHART_PADDING = 10;
 
+// Extra pixels (on top of the font size) a temperature data label occupies above the line:
+// the datalabels box padding plus its offset from the anchor point. The top chart padding
+// reserves `fontSize + this` so the peak label is never clipped at the canvas edge, regardless
+// of the temperature spread.
+const CHART_LABEL_VERTICAL_PADDING = 10;
+
 // Default chart height in pixels at the baseline font size, used as a reference for scaling the chart height dynamically.
 const DEFAULT_CHART_HEIGHT = 130;
 
@@ -357,7 +363,12 @@ export class WfcForecastChart extends LitElement {
     const gridColor = style.getPropertyValue("--wfc-chart-grid-color");
     const fontSize = this._getChartFontSize();
 
-    // Adjust bottom padding based on font size (base: 10 at default font size)
+    // The top must hold the high temperature label (which hangs above the line) in pixels,
+    // since the scale only reserves a small degree buffer there — otherwise the peak label
+    // clips at the canvas edge (issue #139). The bottom only needs to scale its baseline
+    // padding with the font; its generous scale buffer already keeps the low label/precip
+    // bars clear of the edge.
+    const topPadding = fontSize + CHART_LABEL_VERTICAL_PADDING;
     const bottomPadding =
       DEFAULT_CHART_PADDING + (fontSize - DEFAULT_CHART_FONT_SIZE);
 
@@ -374,7 +385,7 @@ export class WfcForecastChart extends LitElement {
       layout: {
         autoPadding: false,
         padding: {
-          top: DEFAULT_CHART_PADDING,
+          top: topPadding,
           bottom: bottomPadding,
           left: 0,
           right: 0,
@@ -802,16 +813,18 @@ export class WfcForecastChart extends LitElement {
   /**
    * Computes the Y-axis boundaries (min and max) for the temperature scale.
    *
-   * This algorithm calculates "artificial" padding to prevent data labels from being pushed
-   * outside the chart area. It specifically addresses the issue where low-temperature labels
-   * (which hang below the data point) get clipped by the x-axis.
+   * This gives the line some breathing room from the chart edges so it does not run flush
+   * against the top/bottom. It is intentionally modest: the room needed for the data *labels*
+   * (which hang above/below the line) is reserved separately, in pixels, via the chart's layout
+   * padding (see `getChartConfig`) — a label needs a fixed pixel height, not an amount that
+   * scales with the temperature spread.
    *
    * The algorithm follows these steps:
    *
    *   1. Identify the absolute min and max from the forecast.
    *   2. Enforce a minimum range of 10° to prevent the chart from looking "flat" or jittery on stable days.
-   *   3. Apply dynamic padding based on the spread, heavily favoring the bottom (35% when low temps are available, otherwise 10%) over the top (20%) to accommodate labels hanging below the line.
-   *   4. Enforces a hard minimum buffer (5° at the bottom) to guarantee sufficient "degree distance" for labels, regardless of how condensed the chart scale is.
+   *   3. Apply dynamic padding based on the spread, favoring the bottom (35% when low temps are available, otherwise 10%) over the top (20%) to accommodate the low line and precipitation bars below.
+   *   4. Enforce a hard minimum buffer (5° at the bottom when a low line is drawn) so the scale never collapses on condensed data.
    *   5. Round values to the nearest integer for cleaner grid lines.
    *
    * @param forecast - The forecast data to compute the scale limits for.

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -140,6 +140,25 @@
       <div class="test-card">
         <weather-forecast-card id="test-card-bug-14-2"></weather-forecast-card>
       </div>
+      <h3>#139 - 1 (issue body — chart font 15px, 14° out of bounds)</h3>
+      <div class="test-card">
+        <weather-forecast-card
+          id="test-card-bug-139"
+          style="--weather-forecast-card-chart-font-size: 15px"
+        ></weather-forecast-card>
+      </div>
+      <h3>#139 - 2 (DWD comment)</h3>
+      <div class="test-card">
+        <weather-forecast-card id="test-card-bug-139-2"></weather-forecast-card>
+      </div>
+      <h3>#139 - 3 (screenshot report, 6 days)</h3>
+      <div class="test-card">
+        <weather-forecast-card id="test-card-bug-139-3"></weather-forecast-card>
+      </div>
+      <h3>#139 - 4 (screenshot report, 5 days)</h3>
+      <div class="test-card">
+        <weather-forecast-card id="test-card-bug-139-4"></weather-forecast-card>
+      </div>
       <div id="error">
         <p id="error-message"></p>
       </div>
@@ -150,6 +169,10 @@
         MockHass,
         ISSUE_14_DAILY_FORECAST,
         ISSUE_14_DAILY_FORECAST_2,
+        ISSUE_139_DAILY_FORECAST,
+        ISSUE_139_DAILY_FORECAST_2,
+        ISSUE_139_DAILY_FORECAST_3,
+        ISSUE_139_DAILY_FORECAST_4,
         TEST_FORECAST_HOURLY_CARDINAL_WIND_BEARING,
         TEST_FORECAST_DAILY_CARDINAL_WIND_BEARING,
       } from "../mocks/index.ts";
@@ -387,6 +410,82 @@
             },
           },
           hassIssue14_2.getHass()
+        );
+
+        // Report 1 (issue body) — the original report. The
+        // distinguishing factor is the larger chart font (15px, set via the
+        // card's inline style in the markup above): it pushes the peak "14°"
+        // label out of the chart bounds so it clips behind the weather icon.
+        const hassIssue139 = new MockHass();
+        hassIssue139.dailyForecast = ISSUE_139_DAILY_FORECAST;
+
+        initializeCard(
+          "test-card-bug-139",
+          {
+            entity: "weather.demo",
+            default_forecast: "daily",
+            forecast: {
+              mode: "chart",
+              daily_slots: 5,
+              use_color_thresholds: true,
+              extra_attribute: "wind_bearing",
+            },
+          },
+          hassIssue139.getHass()
+        );
+
+        // Report 2 (DWD comment) — config mirrors the reporter's YAML.
+        const hassIssue139_2 = new MockHass();
+        hassIssue139_2.dailyForecast = ISSUE_139_DAILY_FORECAST_2;
+
+        initializeCard(
+          "test-card-bug-139-2",
+          {
+            entity: "weather.demo",
+            default_forecast: "daily",
+            forecast: {
+              mode: "chart",
+              daily_slots: 5,
+              use_color_thresholds: true,
+              extra_attribute: "wind_bearing",
+              temperature_precision: 0,
+            },
+          },
+          hassIssue139_2.getHass()
+        );
+
+        // Report 3 — near-flat curve, peaks clustered at 22.5°.
+        const hassIssue139_3 = new MockHass();
+        hassIssue139_3.dailyForecast = ISSUE_139_DAILY_FORECAST_3;
+
+        initializeCard(
+          "test-card-bug-139-3",
+          {
+            entity: "weather.demo",
+            default_forecast: "daily",
+            forecast: {
+              mode: "chart",
+              extra_attribute: "wind_direction",
+            },
+          },
+          hassIssue139_3.getHass()
+        );
+
+        // Report 4 — three identical 22° peaks in a row.
+        const hassIssue139_4 = new MockHass();
+        hassIssue139_4.dailyForecast = ISSUE_139_DAILY_FORECAST_4;
+
+        initializeCard(
+          "test-card-bug-139-4",
+          {
+            entity: "weather.demo",
+            default_forecast: "daily",
+            forecast: {
+              mode: "chart",
+              extra_attribute: "wind_direction",
+            },
+          },
+          hassIssue139_4.getHass()
         );
       });
     </script>

--- a/test/mocks/test-data.ts
+++ b/test/mocks/test-data.ts
@@ -190,6 +190,313 @@ export const ISSUE_14_DAILY_FORECAST_2: ForecastAttribute[] = [
   },
 ];
 
+/**
+ * Issue #139 — daily chart mode temperature labels not scaling/positioning
+ * correctly. https://github.com/troinine/ha-weather-forecast-card/issues/139
+ *
+ * Each dataset below reproduces one report from the issue using the real values
+ * the reporters shared (exact YAML where given, otherwise read from the posted
+ * screenshots). View them via `pnpm dev` to validate the reports.
+ */
+
+/**
+ * Report 1 — the issue body (the original report). Values read
+ * from the original screenshot. The report is specifically about a larger chart
+ * font ("Font size is 15px"): with `weather-forecast-card-chart-font-size: 15px`
+ * the peak label (Tue, 14°) is pushed *out of bounds* above the chart area and
+ * clipped behind the weather icon — the bug the red arrow points at. The test app
+ * card for this dataset sets the 15px chart font so the clipping reproduces.
+ */
+export const ISSUE_139_DAILY_FORECAST: ForecastAttribute[] = [
+  {
+    datetime: new Date().toISOString(),
+    temperature: 12,
+    templow: 3,
+    condition: "sunny",
+    precipitation: 0,
+    wind_speed: 22,
+    wind_bearing: 200,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 86400000).toISOString(),
+    temperature: 11,
+    templow: 0,
+    condition: "sunny",
+    precipitation: 0,
+    wind_speed: 11,
+    wind_bearing: 210,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 2 * 86400000).toISOString(),
+    temperature: 14,
+    templow: 1,
+    condition: "sunny",
+    precipitation: 0,
+    wind_speed: 11,
+    wind_bearing: 220,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 3 * 86400000).toISOString(),
+    temperature: 12,
+    templow: 2,
+    condition: "rainy",
+    precipitation: 2.8,
+    wind_speed: 35,
+    wind_bearing: 240,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 4 * 86400000).toISOString(),
+    temperature: 2,
+    templow: -1,
+    condition: "rainy",
+    precipitation: 2.5,
+    wind_speed: 19,
+    wind_bearing: 260,
+    is_daytime: true,
+  },
+];
+
+/**
+ * Report 2 — DWD daily forecast (exact values from a follow-up comment's YAML).
+ * Big jump from today (9°) to tomorrow (17°); the reporter's red arrow points at
+ * tomorrow's "17°". Config in the test app matches the report: daily_slots 5,
+ * chart mode, color thresholds, wind_bearing extra attribute, precision 0.
+ */
+export const ISSUE_139_DAILY_FORECAST_2: ForecastAttribute[] = [
+  {
+    datetime: new Date().toISOString(),
+    temperature: 9,
+    templow: 6,
+    condition: "partlycloudy",
+    precipitation: 0,
+    pressure: 1026.9,
+    wind_speed: 3.7,
+    wind_bearing: 233.33,
+    uv_index: 4,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 86400000).toISOString(),
+    temperature: 17,
+    templow: 2,
+    condition: "sunny",
+    precipitation: 0,
+    pressure: 1027.2,
+    wind_speed: 9.3,
+    wind_bearing: 126,
+    uv_index: 4,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 2 * 86400000).toISOString(),
+    temperature: 15,
+    templow: 3,
+    condition: "sunny",
+    precipitation: 0,
+    pressure: 1027.6,
+    wind_speed: 16.7,
+    wind_bearing: 53.62,
+    uv_index: 4,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 3 * 86400000).toISOString(),
+    temperature: 14,
+    templow: 1,
+    condition: "partlycloudy",
+    precipitation: 0,
+    pressure: 1025.8,
+    wind_speed: 14.8,
+    wind_bearing: 71.96,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 4 * 86400000).toISOString(),
+    temperature: 10,
+    templow: 4,
+    condition: "rainy",
+    precipitation: 4,
+    pressure: 1023.2,
+    wind_speed: 16.7,
+    wind_bearing: 278.67,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 5 * 86400000).toISOString(),
+    temperature: 13,
+    templow: 1,
+    condition: "sunny",
+    precipitation: 0,
+    pressure: 1023.6,
+    wind_speed: 14.8,
+    wind_bearing: 135.96,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 6 * 86400000).toISOString(),
+    temperature: 10,
+    templow: 2,
+    condition: "cloudy",
+    precipitation: 0,
+    pressure: 1017.3,
+    wind_speed: 18.5,
+    wind_bearing: 76.12,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 7 * 86400000).toISOString(),
+    temperature: 9,
+    templow: 3,
+    condition: "cloudy",
+    precipitation: 0,
+    pressure: 1017.8,
+    wind_speed: 13,
+    wind_bearing: 137.96,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 8 * 86400000).toISOString(),
+    temperature: 10,
+    templow: 2,
+    condition: "cloudy",
+    precipitation: 0,
+    pressure: 1016,
+    wind_speed: 14.8,
+    wind_bearing: 72.04,
+    is_daytime: true,
+  },
+];
+
+/**
+ * Report 3 — follow-up comment (values read from the posted screenshot, 6 days).
+ * Near-flat curve clustered around 19–22.5°; the reporter circled the two peak
+ * days (22.5°, 22.5°) whose labels render misplaced.
+ */
+export const ISSUE_139_DAILY_FORECAST_3: ForecastAttribute[] = [
+  {
+    datetime: new Date().toISOString(),
+    temperature: 21.2,
+    templow: 11.8,
+    condition: "sunny",
+    precipitation: 6.4,
+    wind_speed: 4.7,
+    wind_bearing: 200,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 86400000).toISOString(),
+    temperature: 22.5,
+    templow: 10.4,
+    condition: "sunny",
+    precipitation: 0,
+    wind_speed: 6.1,
+    wind_bearing: 210,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 2 * 86400000).toISOString(),
+    temperature: 22.5,
+    templow: 12,
+    condition: "partlycloudy",
+    precipitation: 0,
+    wind_speed: 6.4,
+    wind_bearing: 220,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 3 * 86400000).toISOString(),
+    temperature: 21.3,
+    templow: 11.2,
+    condition: "sunny",
+    precipitation: 0,
+    wind_speed: 2.8,
+    wind_bearing: 190,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 4 * 86400000).toISOString(),
+    temperature: 19.2,
+    templow: 11.7,
+    condition: "cloudy",
+    precipitation: 0,
+    wind_speed: 3.9,
+    wind_bearing: 180,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 5 * 86400000).toISOString(),
+    temperature: 19.3,
+    templow: 11.9,
+    condition: "cloudy",
+    precipitation: 2.2,
+    wind_speed: 4.7,
+    wind_bearing: 170,
+    is_daytime: true,
+  },
+];
+
+/**
+ * Report 4 — follow-up comment (values read from the posted screenshot, 5 days).
+ * Clearest reproduction: three identical 22° peaks in a row whose labels render
+ * small and overlapping the line, while the 19° and 16° ends render normally.
+ */
+export const ISSUE_139_DAILY_FORECAST_4: ForecastAttribute[] = [
+  {
+    datetime: new Date().toISOString(),
+    temperature: 19,
+    templow: 13,
+    condition: "rainy",
+    precipitation: 1.9,
+    wind_speed: 4.8,
+    wind_bearing: 200,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 86400000).toISOString(),
+    temperature: 22,
+    templow: 13,
+    condition: "rainy",
+    precipitation: 3.7,
+    wind_speed: 5.2,
+    wind_bearing: 210,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 2 * 86400000).toISOString(),
+    temperature: 22,
+    templow: 13,
+    condition: "rainy",
+    precipitation: 0,
+    wind_speed: 5,
+    wind_bearing: 220,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 3 * 86400000).toISOString(),
+    temperature: 22,
+    templow: 12,
+    condition: "rainy",
+    precipitation: 4.5,
+    wind_speed: 5.5,
+    wind_bearing: 200,
+    is_daytime: true,
+  },
+  {
+    datetime: new Date(Date.now() + 4 * 86400000).toISOString(),
+    temperature: 16,
+    templow: 10,
+    condition: "rainy",
+    precipitation: 3.0,
+    wind_speed: 6,
+    wind_bearing: 190,
+    is_daytime: true,
+  },
+];
+
 export const TEST_FORECAST_DAILY: ForecastAttribute[] = Array.from(
   { length: 5 },
   (_, i) => ({

--- a/test/weather-forecast-chart.test.ts
+++ b/test/weather-forecast-chart.test.ts
@@ -1205,17 +1205,21 @@ describe("weather-forecast-card chart", () => {
       expect(largerChart.options.layout?.padding?.bottom).toBe(14);
     });
 
-    it("should keep top padding fixed at 10 regardless of font size", async () => {
+    it("should reserve top padding for the high temperature label (issue #139)", async () => {
+      // The top padding holds the high label (which hangs above the line) in pixels
+      // so it is never clipped at the canvas edge — the font size plus a fixed
+      // allowance (10) for the label box and offset, independent of the spread.
       const { chart: defaultChart } = await createCardFixture();
       // @ts-expect-error: layout type
-      expect(defaultChart.options.layout?.padding?.top).toBe(10);
+      expect(defaultChart.options.layout?.padding?.top).toBe(22); // 12 + 10
 
+      // A larger font needs proportionally more room for the taller label.
       const { chart: largerChart } = await createCardFixture(
         {},
         { "--wfc-chart-font-size": "16" }
       );
       // @ts-expect-error: layout type
-      expect(largerChart.options.layout?.padding?.top).toBe(10);
+      expect(largerChart.options.layout?.padding?.top).toBe(26); // 16 + 10
     });
 
     it("should scale bar label offset with font size", async () => {


### PR DESCRIPTION
Fixes #139.

The high temperature label could be clipped at the top of the daily chart, especially with a larger chart font. The top now reserves the label's height in pixels (`fontSize + 10`) so the peak label is never cut off, independent of the temperature spread.

Adds reproduction data/cards for the reported cases under the test app's "Bug fixes" section.