### PR TITLE
feat: custom and arbitrary current weather attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `current` object controls the display of current weather information and att
 
 #### Custom Attributes
 
-Similar to the `current.temperature_entity` option, each displayed attribute can be customized. You can override an attribute's value with a custom sensor entity (useful when your weather integration doesn't provide it, or when you have a more accurate local sensor), give it a custom `label` or `icon`, or display an arbitrary entity that isn't a standard weather attribute at all.
+Similar to the `current.temperature_entity` option, each displayed attribute can be customized. You can override an attribute's value with a custom sensor entity (useful when your weather integration doesn't provide it, or when you have a more accurate local sensor), give it a custom `label` or `icon`, or display an arbitrary entity that isn't a standard weather attribute.
 
 **Object format for attributes:**
 
@@ -172,7 +172,7 @@ current:
 ```
 
 ```yaml
-# Arbitrary entities (no weather attribute name) — displays the entity's state
+# Arbitrary entities (no weather attribute name), shows the entity state
 current:
   show_attributes:
     - entity: sensor.pollen_count
@@ -183,7 +183,7 @@ current:
 ```
 
 > [!TIP]
-> The card editor provides entity selectors with appropriate device class filtering when you select attributes, plus optional label and icon fields per attribute. Expand the "Attribute entities" section to configure them. Entity-only (arbitrary) attributes are preserved when editing but are currently authored in YAML.
+> The card editor supports this too. When you select standard attributes, the "Attribute entities" section provides an entity selector (with device class filtering) plus optional label and icon fields for each. Arbitrary entity attributes can be added and removed under the "Custom entity attributes" section.
 
 ### Forecast Object
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The `current` object controls the display of current weather information and att
 | Name                       | Type                       | Default  | Description                                                                                                                                                                                                                                                                                                                                                |
 | :------------------------- | :------------------------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `temperature_entity`       | `string`                   | optional | Bring your own temperature entity to override the temperature from the main weather `entity`. **Note:** The root level `temperature_entity` is deprecated but still supported and will be migrated automatically when editing the card using the card editor.                                                                                              |
-| `show_attributes`          | `boolean`/`string`/`array` | optional | Display weather attributes below current conditions. Set to `true` to show all available attributes, `false` to hide all, a single attribute name (e.g., `"humidity"`), or an array of attribute names or objects. See [Custom Attribute Entities](#custom-attribute-entities) for advanced configuration.                                                 |
-| `secondary_info_attribute` | `string`                   | optional | Controls which secondary info is displayed below current temperature. Supports all available weather attributes. If not set, or if the given attribute is not available in the weather entity, it will default to temperature extrema (high/low) if available, if not available then `precipitation` and if precipitation isn't available then `humidity`. |
+| `show_attributes`          | `boolean`/`string`/`array` | optional | Display weather attributes below current conditions. Set to `true` to show all available attributes, `false` to hide all, a single attribute name (e.g., `"humidity"`), or an array of attribute names or objects. Objects can override the value `entity`, `label` and `icon`, or display an arbitrary entity. See [Custom Attributes](#custom-attributes) for advanced configuration.                                                 |
+| `secondary_info_attribute` | `string`/`object`          | optional | Controls which secondary info is displayed below current temperature. Supports all available weather attributes. Can also be an object `{ name?, entity?, icon? }` to source the value from a custom entity (see [Custom Attributes](#custom-attributes); note that `label` is not rendered for secondary info). If not set, or if the given attribute is not available in the weather entity, it will default to temperature extrema (high/low) if available, if not available then `precipitation` and if precipitation isn't available then `humidity`. |
 | `temperature_precision`    | `number`                   | optional | Number of decimal places to display for temperature values (0-2). Applies to current temperature, high/low temperatures, and temperature-related attributes like dew point and apparent temperature.                                                                                                                                                       |
 
 **Available attributes:**
@@ -114,16 +114,21 @@ The `current` object controls the display of current weather information and att
 > [!NOTE]
 > Attributes are only rendered if the data is available from your weather entity (or custom sensor entity if configured). If an attribute is not provided by your weather integration, it will not be displayed even if configured.
 
-#### Custom Attribute Entities
+#### Custom Attributes
 
-Similar to the `current.temperature_entity` option, you can override individual attribute values with custom sensor entities. This is useful when your weather integration doesn't provide certain attributes or when you have more accurate local sensors.
+Similar to the `current.temperature_entity` option, each displayed attribute can be customized. You can override an attribute's value with a custom sensor entity (useful when your weather integration doesn't provide it, or when you have a more accurate local sensor), give it a custom `label` or `icon`, or display an arbitrary entity that isn't a standard weather attribute at all.
 
 **Object format for attributes:**
 
-| Property | Type     | Description                                                            |
-| :------- | :------- | :--------------------------------------------------------------------- |
-| `name`   | `string` | The attribute name (e.g., `humidity`, `pressure`)                      |
-| `entity` | `string` | Optional sensor entity ID to use instead of the weather entity's value |
+| Property | Type     | Description                                                                                                                          |
+| :------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| `name`   | `string` | Optional. A known weather attribute (e.g., `humidity`, `pressure`). Omit it for an entity-only item that displays a custom entity's state. |
+| `entity` | `string` | Optional. Entity ID to source the value from instead of the weather entity. **Required when `name` is omitted.**                    |
+| `label`  | `string` | Optional. Custom label shown instead of the derived attribute name or the entity's friendly name.                                   |
+| `icon`   | `string` | Optional. Custom icon (e.g., `mdi:weather-windy`) shown instead of the default attribute or entity icon.                            |
+
+> [!NOTE]
+> Each item must have a `name`, an `entity`, or both. An entity-only item (no `name`) is displayed as an "arbitrary" attribute: its value is the entity's state and its label defaults to the entity's friendly name unless you set `label`.
 
 **Configuration examples:**
 
@@ -157,8 +162,28 @@ current:
     - wind_speed # Uses weather entity
 ```
 
+```yaml
+# Custom label and icon
+current:
+  show_attributes:
+    - name: wind_speed
+      label: Wind
+      icon: mdi:weather-windy
+```
+
+```yaml
+# Arbitrary entities (no weather attribute name) — displays the entity's state
+current:
+  show_attributes:
+    - entity: sensor.pollen_count
+      label: Pollen
+      icon: mdi:flower
+    - entity: sensor.uv_today # label defaults to the entity's friendly name
+    - humidity # Standard weather attribute alongside custom ones
+```
+
 > [!TIP]
-> The card editor provides entity selectors with appropriate device class filtering when you select attributes. Expand the "Attribute entities" section to configure custom sensors for each selected attribute.
+> The card editor provides entity selectors with appropriate device class filtering when you select attributes, plus optional label and icon fields per attribute. Expand the "Attribute entities" section to configure them. Entity-only (arbitrary) attributes are preserved when editing but are currently authored in YAML.
 
 ### Forecast Object
 

--- a/src/components/wfc-current-weather-attributes.ts
+++ b/src/components/wfc-current-weather-attributes.ts
@@ -2,11 +2,15 @@ import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { capitalize } from "lodash-es";
 import memoizeOne from "memoize-one";
-import { ExtendedHomeAssistant, WeatherForecastCardConfig } from "../types";
+import {
+  CURRENT_WEATHER_ATTRIBUTES,
+  ExtendedHomeAssistant,
+  WeatherForecastCardConfig,
+} from "../types";
 import {
   formatCustomEntityAttributeValue,
   formatWeatherEntityAttributeValue,
-  WEATHER_ATTRIBUTE_ICON_MAP,
+  resolveAttributeIcon,
   WeatherEntity,
 } from "../data/weather";
 import type { NormalizedAttributeConfig } from "./wfc-current-weather";
@@ -48,23 +52,36 @@ export class WfcCurrentWeatherAttributes extends LitElement {
   private _renderAttribute(
     attrConfig: NormalizedAttributeConfig
   ): TemplateResult | typeof nothing {
-    const { name: attribute, entity: customEntityId } = attrConfig;
+    if (!attrConfig || (!attrConfig.name && !attrConfig.entity)) {
+      return nothing;
+    }
 
-    // Use custom entity value if specified, otherwise use weather entity
-    const value = customEntityId
-      ? formatCustomEntityAttributeValue(
-          this.hass,
-          this.weatherEntity,
-          this.config,
-          attribute,
-          customEntityId
-        )
-      : formatWeatherEntityAttributeValue(
-          this.hass,
-          this.weatherEntity,
-          this.config,
-          attribute
-        );
+    const {
+      name: attribute,
+      entity: customEntityId,
+      label: explicitLabel,
+      icon: explicitIcon,
+    } = attrConfig;
+
+    // Resolve the value from the custom entity if one is given, otherwise from
+    // the weather entity using the attribute name.
+    let value: string | undefined;
+    if (customEntityId) {
+      value = formatCustomEntityAttributeValue(
+        this.hass,
+        this.weatherEntity,
+        this.config,
+        attribute,
+        customEntityId
+      );
+    } else if (attribute) {
+      value = formatWeatherEntityAttributeValue(
+        this.hass,
+        this.weatherEntity,
+        this.config,
+        attribute
+      );
+    }
 
     if (!value) {
       return nothing;
@@ -73,10 +90,11 @@ export class WfcCurrentWeatherAttributes extends LitElement {
     const stateObj = customEntityId
       ? this.hass.states[customEntityId] || this.weatherEntity
       : this.weatherEntity;
-    const icon =
-      customEntityId && this.hass.states[customEntityId]?.attributes?.icon
-        ? this.hass.states[customEntityId]?.attributes.icon
-        : WEATHER_ATTRIBUTE_ICON_MAP[attribute];
+
+    const customEntity = customEntityId
+      ? this.hass.states[customEntityId]
+      : undefined;
+    const icon = resolveAttributeIcon(attribute, explicitIcon, customEntity);
 
     return html`
       <div class="wfc-current-attribute">
@@ -88,11 +106,31 @@ export class WfcCurrentWeatherAttributes extends LitElement {
           .icon=${icon}
         ></ha-attribute-icon>
         <span class="wfc-current-attribute-name">
-          ${this.localize(attribute)}
+          ${this.resolveLabel(attribute, explicitLabel, customEntity)}
         </span>
         <span class="wfc-current-attribute-value">${value}</span>
       </div>
     `;
+  }
+
+  private resolveLabel(
+    attribute: string | undefined,
+    explicitLabel: string | undefined,
+    customEntity: { attributes?: { friendly_name?: string } } | undefined
+  ): string {
+    if (explicitLabel) {
+      return explicitLabel;
+    }
+    if (
+      attribute &&
+      (CURRENT_WEATHER_ATTRIBUTES as ReadonlyArray<string>).includes(attribute)
+    ) {
+      return this.localize(attribute);
+    }
+    return (
+      customEntity?.attributes?.friendly_name ??
+      (attribute ? capitalize(attribute).replace(/_/g, " ") : "")
+    );
   }
 
   private localize = (attribute: string): string => {

--- a/src/components/wfc-current-weather.ts
+++ b/src/components/wfc-current-weather.ts
@@ -17,6 +17,7 @@ import {
 } from "../types";
 import {
   ForecastAttribute,
+  formatCustomEntityAttributeValue,
   formatTemperature,
   formatWeatherEntityAttributeValue,
   WEATHER_ATTRIBUTE_ICON_MAP,
@@ -27,8 +28,10 @@ import "./wfc-weather-condition-icon-provider";
 import "./wfc-current-weather-attributes";
 
 export type NormalizedAttributeConfig = {
-  name: CurrentWeatherAttributes;
+  name?: CurrentWeatherAttributes | string;
   entity?: string;
+  label?: string;
+  icon?: string;
 };
 
 type SecondaryInfo = {
@@ -175,17 +178,24 @@ export class WfcCurrentWeather extends LitElement {
 
     // Handle single object: { name: "humidity", entity: "sensor.my_humidity" }
     if (!Array.isArray(showAttr) && typeof showAttr === "object") {
-      return [showAttr as CurrentWeatherAttributeConfig];
+      return showAttr.name || showAttr.entity
+        ? [showAttr as CurrentWeatherAttributeConfig]
+        : [];
     }
 
-    // Handle array: mixed strings and objects
+    // Handle array: mixed strings and objects. The editor inserts a null
+    // placeholder when a new list item is added, so drop null/empty entries.
+    // Keep any item that identifies a value source: a name (weather attribute)
+    // or an entity (arbitrary custom attribute).
     if (Array.isArray(showAttr)) {
-      return showAttr.map((item) => {
-        if (typeof item === "string") {
-          return { name: item as CurrentWeatherAttributes };
-        }
-        return item as CurrentWeatherAttributeConfig;
-      });
+      return showAttr
+        .filter((item) => item != null)
+        .map((item) =>
+          typeof item === "string"
+            ? { name: item as CurrentWeatherAttributes }
+            : (item as CurrentWeatherAttributeConfig)
+        )
+        .filter((item) => Boolean(item.name) || Boolean(item.entity));
     }
 
     return [];
@@ -232,25 +242,57 @@ export class WfcCurrentWeather extends LitElement {
   private getSecondaryWeatherAttribute(): SecondaryInfo | null {
     const forecast = this.hourlyForecast;
 
-    const secondaryInfoAttribute =
+    const rawSecondaryInfoAttribute =
       this.config.current?.secondary_info_attribute;
-    if (secondaryInfoAttribute) {
-      if (secondaryInfoAttribute in this.weatherEntity.attributes) {
+
+    if (rawSecondaryInfoAttribute) {
+      // Normalize to object form
+      const secondaryAttr =
+        typeof rawSecondaryInfoAttribute === "string"
+          ? { name: rawSecondaryInfoAttribute as CurrentWeatherAttributes }
+          : rawSecondaryInfoAttribute;
+
+      const { name, entity: customEntityId, icon: explicitIcon } = secondaryAttr;
+
+      if (customEntityId) {
+        // Custom entity path: skip the in-attributes check
+        const value = formatCustomEntityAttributeValue(
+          this.hass,
+          this.weatherEntity,
+          this.config,
+          name,
+          customEntityId
+        );
+
+        if (value != null) {
+          const customEntity = this.hass.states[customEntityId];
+          const icon =
+            explicitIcon ??
+            customEntity?.attributes?.icon ??
+            (name
+              ? (EXTENDED_WEATHER_ATTRIBUTE_ICON_MAP as Record<string, string>)[
+                  name
+                ]
+              : undefined);
+
+          return { icon, value };
+        }
+      } else if (name && name in this.weatherEntity.attributes) {
+        // Weather entity path: existing behavior
+        const nameAsKnown = name as CurrentWeatherAttributes;
         const weatherAttrIcon =
-          EXTENDED_WEATHER_ATTRIBUTE_ICON_MAP[secondaryInfoAttribute];
+          EXTENDED_WEATHER_ATTRIBUTE_ICON_MAP[nameAsKnown];
 
         const value = formatWeatherEntityAttributeValue(
           this.hass,
           this.weatherEntity,
           this.config,
-          secondaryInfoAttribute
+          name
         );
 
         if (value != null) {
-          return {
-            icon: weatherAttrIcon,
-            value,
-          };
+          const icon = explicitIcon ?? weatherAttrIcon;
+          return { icon, value };
         }
       }
     }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -601,13 +601,33 @@ export const aggregateHourlyForecastData = (
   return groupedForecast;
 };
 
+export const DEFAULT_ATTRIBUTE_ICON = "mdi:gauge";
+
+export const resolveAttributeIcon = (
+  name: string | undefined,
+  explicitIcon?: string,
+  customEntity?: { attributes?: { icon?: string } }
+): string => {
+  if (explicitIcon) {
+    return explicitIcon;
+  }
+  if (customEntity?.attributes?.icon) {
+    return customEntity.attributes.icon;
+  }
+  const mapped = name
+    ? (WEATHER_ATTRIBUTE_ICON_MAP as Record<string, string>)[name]
+    : undefined;
+  return mapped ?? DEFAULT_ATTRIBUTE_ICON;
+};
+
 export const formatWeatherEntityAttributeValue = (
   hass: ExtendedHomeAssistant,
   weatherEntity: WeatherEntity,
   config: WeatherForecastCardConfig,
-  attribute: CurrentWeatherAttributes
+  attribute: CurrentWeatherAttributes | string
 ): string | undefined => {
-  const value = weatherEntity.attributes[attribute];
+  const value =
+    weatherEntity.attributes[attribute as keyof typeof weatherEntity.attributes];
 
   if (value === undefined) {
     return undefined;
@@ -620,7 +640,7 @@ export const formatWeatherEntityAttributeValue = (
   // hass.formatEntityAttributeValue does not support wind_gust_speed yet
   if (attribute === "wind_gust_speed") {
     const unit = getWeatherUnit(hass, weatherEntity, "wind_gust_speed");
-    const windGustSpeed = formatNumber(value, hass.locale);
+    const windGustSpeed = formatNumber(value as number, hass.locale);
 
     return `${windGustSpeed} ${unit}`;
   }
@@ -637,7 +657,7 @@ export const formatWeatherEntityAttributeValue = (
     return formatTemperature(
       hass,
       weatherEntity,
-      value,
+      value as number | string,
       config.current?.temperature_precision
     );
   }
@@ -649,7 +669,7 @@ export const formatCustomEntityAttributeValue = (
   hass: ExtendedHomeAssistant,
   weatherEntity: WeatherEntity,
   config: WeatherForecastCardConfig,
-  attribute: CurrentWeatherAttributes,
+  attribute: CurrentWeatherAttributes | string | undefined,
   customEntityId: string
 ): string | undefined => {
   const customEntity = hass.states[customEntityId];

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -640,7 +640,7 @@ export class WeatherForecastCardEditor
         ></ha-form>
         <ha-icon-button
           .path=${mdiDelete}
-          .label=${"Remove"}
+          .label=${this.hass.localize("ui.common.remove") || "Remove"}
           @click=${() => this._removeCustomAttribute(index)}
         ></ha-icon-button>
       </div>
@@ -699,12 +699,14 @@ export class WeatherForecastCardEditor
   private _commitCustomAttributes(
     custom: CurrentWeatherAttributeConfig[]
   ): void {
-    const known = extractKnownItems(this._config.current?.show_attributes);
     const newConfig: WeatherForecastCardEditorConfig = {
       ...this._config,
       current: {
         ...this._config.current,
-        show_attributes: [...known, ...custom],
+        show_attributes: rebuildShowAttributesWithCustom(
+          this._config.current?.show_attributes,
+          custom
+        ),
       },
     };
 
@@ -1063,7 +1065,7 @@ export const buildShowAttributes = (
     icon: Record<string, string>;
   },
   customItems: CurrentWeatherAttributeConfig[]
-): true | (string | CurrentWeatherAttributeConfig)[] => {
+): true | (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[] => {
   const allKnownSelected = CURRENT_WEATHER_ATTRIBUTES.every((attr) =>
     selectedKnownNames.includes(attr)
   );
@@ -1076,7 +1078,7 @@ export const buildShowAttributes = (
     return true;
   }
 
-  const known: (string | CurrentWeatherAttributeConfig)[] =
+  const known: (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[] =
     selectedKnownNames.map((name) => {
       const e = overrides.entity[name];
       const l = overrides.label[name];
@@ -1089,7 +1091,7 @@ export const buildShowAttributes = (
           ...(i ? { icon: i } : {}),
         };
       }
-      return name;
+      return name as CurrentWeatherAttributes;
     });
 
   return [...known, ...customItems];
@@ -1136,6 +1138,36 @@ export const extractKnownItems = (
   }
 
   return result;
+};
+
+// Rebuilds show_attributes from the existing known items plus an edited set of
+// custom items. Routes through buildShowAttributes so canonicalization (e.g.
+// collapsing back to `true` when all known attributes remain with no overrides
+// or custom items) stays consistent with the main form's update path.
+export const rebuildShowAttributesWithCustom = (
+  previousShowAttributes: unknown,
+  custom: CurrentWeatherAttributeConfig[]
+): true | (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[] => {
+  const known = extractKnownItems(previousShowAttributes);
+  const selectedKnownNames: string[] = [];
+  const overrides = {
+    entity: {} as Record<string, string>,
+    label: {} as Record<string, string>,
+    icon: {} as Record<string, string>,
+  };
+
+  for (const item of known) {
+    if (typeof item === "string") {
+      selectedKnownNames.push(item);
+    } else if (item.name) {
+      selectedKnownNames.push(item.name);
+      if (item.entity) overrides.entity[item.name] = item.entity;
+      if (item.label) overrides.label[item.name] = item.label;
+      if (item.icon) overrides.icon[item.name] = item.icon;
+    }
+  }
+
+  return buildShowAttributes(selectedKnownNames, overrides, custom);
 };
 
 const moveDottedKeysToNested = (obj: Record<string, any>) => {

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { LitElement, html, TemplateResult, nothing } from "lit";
+import { LitElement, html, css, TemplateResult, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { mdiDelete, mdiPlaylistPlus } from "@mdi/js";
 import memoizeOne from "memoize-one";
 import { capitalize } from "lodash-es";
 import {
@@ -94,6 +95,37 @@ export class WeatherForecastCardEditor
 {
   @property({ attribute: false }) public hass!: ExtendedHomeAssistant;
   @state() private _config!: WeatherForecastCardEditorConfig;
+
+  static styles = css`
+    ha-expansion-panel {
+      display: block;
+      margin-top: 24px;
+      --expansion-panel-content-padding: 0;
+      border-radius: var(--ha-border-radius-md, 12px);
+      --ha-card-border-radius: var(--ha-border-radius-md, 12px);
+    }
+    .custom-attributes {
+      padding: 12px;
+    }
+    .custom-attributes p {
+      margin: 0 0 24px;
+    }
+    .custom-attribute-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .custom-attribute-row ha-form {
+      flex: 1;
+      min-width: 0;
+    }
+    .custom-attribute-row ha-icon-button {
+      --mdc-icon-button-size: 40px;
+      color: var(--secondary-text-color);
+      margin-top: 4px;
+    }
+  `;
 
   public setConfig(config: WeatherForecastCardEditorConfig): void {
     this._config = config;
@@ -555,7 +587,128 @@ export class WeatherForecastCardEditor
         @value-changed=${this._valueChanged}
       >
       </ha-form>
+      ${this._renderCustomAttributes()}
     `;
+  }
+
+  private _renderCustomAttributes(): TemplateResult {
+    const customItems = extractCustomAttributes(
+      this._config.current?.show_attributes
+    );
+
+    return html`
+      <ha-expansion-panel outlined>
+        <div slot="header" role="heading" aria-level="3">
+          Custom entity attributes
+        </div>
+        <div class="custom-attributes">
+          <p>
+            Display any entity's state as an attribute. Pick an entity and
+            optionally override its label and icon.
+          </p>
+          ${customItems.map((item, index) =>
+            this._renderCustomAttributeRow(item, index)
+          )}
+          <ha-button
+            size="small"
+            appearance="filled"
+            variant="brand"
+            @click=${this._addCustomAttribute}
+          >
+            <ha-svg-icon slot="start" .path=${mdiPlaylistPlus}></ha-svg-icon>
+            ${this.hass.localize("ui.panel.lovelace.editor.entities.add") ||
+            "Add entity"}
+          </ha-button>
+        </div>
+      </ha-expansion-panel>
+    `;
+  }
+
+  private _renderCustomAttributeRow(
+    item: CurrentWeatherAttributeConfig,
+    index: number
+  ): TemplateResult {
+    return html`
+      <div class="custom-attribute-row">
+        <ha-form
+          .hass=${this.hass}
+          .data=${item}
+          .schema=${CUSTOM_ATTRIBUTE_ROW_SCHEMA}
+          .computeLabel=${this._computeCustomAttributeLabel}
+          @value-changed=${(ev: CustomEvent) =>
+            this._customAttributeChanged(index, ev)}
+        ></ha-form>
+        <ha-icon-button
+          .path=${mdiDelete}
+          .label=${"Remove"}
+          @click=${() => this._removeCustomAttribute(index)}
+        ></ha-icon-button>
+      </div>
+    `;
+  }
+
+  private _computeCustomAttributeLabel = (schema: { name: string }): string => {
+    switch (schema.name) {
+      case "entity":
+        return (
+          this.hass.localize("ui.panel.lovelace.editor.card.generic.entity") ||
+          "Entity"
+        );
+      case "label":
+        return (
+          this.hass.localize("ui.panel.lovelace.editor.card.generic.name") ||
+          "Name"
+        );
+      case "icon":
+        return (
+          this.hass.localize("ui.panel.lovelace.editor.card.generic.icon") ||
+          "Icon"
+        );
+      default:
+        return schema.name;
+    }
+  };
+
+  private _addCustomAttribute = (): void => {
+    const custom = extractCustomAttributes(
+      this._config.current?.show_attributes
+    );
+    this._commitCustomAttributes([...custom, {}]);
+  };
+
+  private _removeCustomAttribute = (index: number): void => {
+    const custom = extractCustomAttributes(
+      this._config.current?.show_attributes
+    );
+    custom.splice(index, 1);
+    this._commitCustomAttributes(custom);
+  };
+
+  private _customAttributeChanged = (
+    index: number,
+    ev: CustomEvent
+  ): void => {
+    ev.stopPropagation();
+    const custom = extractCustomAttributes(
+      this._config.current?.show_attributes
+    );
+    custom[index] = ev.detail.value as CurrentWeatherAttributeConfig;
+    this._commitCustomAttributes(custom);
+  };
+
+  private _commitCustomAttributes(
+    custom: CurrentWeatherAttributeConfig[]
+  ): void {
+    const known = extractKnownItems(this._config.current?.show_attributes);
+    const newConfig: WeatherForecastCardEditorConfig = {
+      ...this._config,
+      current: {
+        ...this._config.current,
+        show_attributes: [...known, ...custom],
+      },
+    };
+
+    fireEvent(this, "config-changed", { config: newConfig });
   }
 
   private _getSelectedAttributes(
@@ -942,6 +1095,49 @@ export const buildShowAttributes = (
   return [...known, ...customItems];
 };
 
+// Schema for a single custom-attribute editor row (entity + optional label/icon).
+const CUSTOM_ATTRIBUTE_ROW_SCHEMA = [
+  { name: "entity", selector: { entity: {} } },
+  { name: "label", selector: { text: {} } },
+  { name: "icon", selector: { icon: {} } },
+] as const;
+
+// Returns the KNOWN items (verbatim) from a show_attributes config value.
+// Complements extractCustomAttributes so the two together reconstruct the list.
+export const extractKnownItems = (
+  showAttributes: unknown
+): (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[] => {
+  if (showAttributes === true) {
+    return [...CURRENT_WEATHER_ATTRIBUTES];
+  }
+  if (typeof showAttributes === "string") {
+    return isKnownAttribute(showAttributes) ? [showAttributes] : [];
+  }
+  if (!Array.isArray(showAttributes)) {
+    return [];
+  }
+
+  const result: (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[] =
+    [];
+
+  for (const item of showAttributes) {
+    if (item == null) continue;
+
+    if (typeof item === "string") {
+      if (isKnownAttribute(item)) {
+        result.push(item);
+      }
+    } else if (typeof item === "object") {
+      const cfg = item as CurrentWeatherAttributeConfig;
+      if (isKnownAttribute(cfg.name)) {
+        result.push(cfg);
+      }
+    }
+  }
+
+  return result;
+};
+
 const moveDottedKeysToNested = (obj: Record<string, any>) => {
   const result: Record<string, any> = { ...obj };
 
@@ -998,7 +1194,7 @@ export const denormalizeConfig = (obj: Record<string, any>) => {
   // Handle show_attributes: extract only KNOWN items for the multiselect;
   // flatten per-attribute entity/label/icon overrides for the form fields.
   // Custom items (entity-only or arbitrary-name) are preserved via _valueChanged
-  // reading this._config directly — do NOT put them in normalizedAttrs.
+  // reading this._config directly, so do NOT put them in normalizedAttrs.
   const showAttrs = result["current.show_attributes"];
   if (Array.isArray(showAttrs)) {
     const normalizedAttrs: string[] = [];

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -44,6 +44,7 @@ type HaFormSelector =
   | { entity: { domain?: string; device_class?: string | string[] } }
   | { boolean: {} }
   | { text: {} }
+  | { icon: {} }
   | { entity_name: {} }
   | { number: { min?: number; max?: number } }
   | { ui_action: { default_action: string } }
@@ -63,6 +64,8 @@ type HaFormSchema = {
     | `current.${keyof WeatherForecastCardCurrentConfig}`
     | `forecast_action.${keyof WeatherForecastCardForecastActionConfig}`
     | `current.attribute_entity_${CurrentWeatherAttributes}`
+    | `current.attribute_label_${CurrentWeatherAttributes}`
+    | `current.attribute_icon_${CurrentWeatherAttributes}`
     | "attribute_entities"
     | "";
   type?: string;
@@ -445,16 +448,28 @@ export class WeatherForecastCardEditor
       return [];
     }
 
-    const attributeEntitySchemas: HaFormSchema[] = selectedAttributes.map(
+    const attributeFieldSchemas: HaFormSchema[] = selectedAttributes.flatMap(
       (attribute) => {
         const deviceClass = ATTRIBUTE_DEVICE_CLASS_MAP[attribute];
-        return {
-          name: `current.attribute_entity_${attribute}`,
-          optional: true,
-          selector: deviceClass
-            ? { entity: { domain: "sensor", device_class: deviceClass } }
-            : { entity: { domain: "sensor" } },
-        };
+        return [
+          {
+            name: `current.attribute_entity_${attribute}` as const,
+            optional: true,
+            selector: deviceClass
+              ? { entity: { domain: "sensor", device_class: deviceClass } }
+              : { entity: { domain: "sensor" } },
+          },
+          {
+            name: `current.attribute_label_${attribute}` as const,
+            optional: true,
+            selector: { text: {} },
+          },
+          {
+            name: `current.attribute_icon_${attribute}` as const,
+            optional: true,
+            selector: { icon: {} },
+          },
+        ];
       }
     );
 
@@ -463,7 +478,7 @@ export class WeatherForecastCardEditor
         name: "attribute_entities",
         type: "expandable",
         flatten: true,
-        schema: attributeEntitySchemas,
+        schema: attributeFieldSchemas,
       },
     ];
   };
@@ -566,6 +581,22 @@ export class WeatherForecastCardEditor
   }
 
   private _computeLabel = (schema: HaFormSchema): string | undefined => {
+    if (schema.name.startsWith("current.attribute_label_")) {
+      const attribute = schema.name.replace("current.attribute_label_", "");
+      const attributeLabel =
+        this.localize(`ui.card.weather.attributes.${attribute}`) ||
+        capitalize(attribute).replace(/_/g, " ");
+      return `${attributeLabel} label`;
+    }
+
+    if (schema.name.startsWith("current.attribute_icon_")) {
+      const attribute = schema.name.replace("current.attribute_icon_", "");
+      const attributeLabel =
+        this.localize(`ui.card.weather.attributes.${attribute}`) ||
+        capitalize(attribute).replace(/_/g, " ");
+      return `${attributeLabel} icon`;
+    }
+
     if (schema.name.startsWith("current.attribute_entity_")) {
       const attribute = schema.name.replace("current.attribute_entity_", "");
       const attributeLabel =
@@ -764,42 +795,47 @@ export class WeatherForecastCardEditor
       }
     }
 
-    // Convert show_attributes to object format if custom entities are specified
+    // Convert show_attributes to object format, preserving custom items and
+    // collecting per-attribute entity/label/icon overrides from the flat form keys
     if (newConfig?.current) {
-      const attributeEntities: Record<string, string> = {};
+      const entityOverrides: Record<string, string> = {};
+      const labelOverrides: Record<string, string> = {};
+      const iconOverrides: Record<string, string> = {};
 
       for (const key of Object.keys(newConfig.current)) {
         if (key.startsWith("attribute_entity_")) {
-          const attribute = key.replace(
-            "attribute_entity_",
-            ""
-          ) as CurrentWeatherAttributes;
-          const entity = newConfig.current[key];
-          if (entity) {
-            attributeEntities[attribute] = entity;
+          const attribute = key.replace("attribute_entity_", "");
+          const value = newConfig.current[key];
+          if (value) {
+            entityOverrides[attribute] = value;
+          }
+          delete newConfig.current[key];
+        } else if (key.startsWith("attribute_label_")) {
+          const attribute = key.replace("attribute_label_", "");
+          const value = newConfig.current[key];
+          if (value) {
+            labelOverrides[attribute] = value;
+          }
+          delete newConfig.current[key];
+        } else if (key.startsWith("attribute_icon_")) {
+          const attribute = key.replace("attribute_icon_", "");
+          const value = newConfig.current[key];
+          if (value) {
+            iconOverrides[attribute] = value;
           }
           delete newConfig.current[key];
         }
       }
 
       if (Array.isArray(newConfig.current.show_attributes)) {
-        const hasCustomEntities = Object.keys(attributeEntities).length > 0;
-        const allSelected = CURRENT_WEATHER_ATTRIBUTES.every((attribute) =>
-          newConfig.current.show_attributes.includes(attribute)
+        const customItems = extractCustomAttributes(
+          this._config?.current?.show_attributes
         );
-
-        if (hasCustomEntities) {
-          newConfig.current.show_attributes =
-            newConfig.current.show_attributes.map((attr: string) => {
-              const entity = attributeEntities[attr];
-              if (entity) {
-                return { name: attr, entity };
-              }
-              return attr;
-            });
-        } else if (allSelected) {
-          newConfig.current.show_attributes = true;
-        }
+        newConfig.current.show_attributes = buildShowAttributes(
+          newConfig.current.show_attributes,
+          { entity: entityOverrides, label: labelOverrides, icon: iconOverrides },
+          customItems
+        );
       }
     }
 
@@ -832,6 +868,80 @@ export class WeatherForecastCardEditor
   };
 }
 
+export const isKnownAttribute = (
+  name: unknown
+): name is CurrentWeatherAttributes =>
+  typeof name === "string" &&
+  (CURRENT_WEATHER_ATTRIBUTES as ReadonlyArray<string>).includes(name);
+
+export const extractCustomAttributes = (
+  showAttributes: unknown
+): CurrentWeatherAttributeConfig[] => {
+  if (!Array.isArray(showAttributes)) {
+    return [];
+  }
+
+  const result: CurrentWeatherAttributeConfig[] = [];
+
+  for (const item of showAttributes) {
+    if (item == null) continue;
+
+    if (typeof item === "string") {
+      if (!isKnownAttribute(item)) {
+        result.push({ name: item });
+      }
+    } else if (typeof item === "object") {
+      const cfg = item as CurrentWeatherAttributeConfig;
+      // Custom = no name OR name is not a known attribute
+      if (!isKnownAttribute(cfg.name)) {
+        result.push(cfg);
+      }
+    }
+  }
+
+  return result;
+};
+
+export const buildShowAttributes = (
+  selectedKnownNames: string[],
+  overrides: {
+    entity: Record<string, string>;
+    label: Record<string, string>;
+    icon: Record<string, string>;
+  },
+  customItems: CurrentWeatherAttributeConfig[]
+): true | (string | CurrentWeatherAttributeConfig)[] => {
+  const allKnownSelected = CURRENT_WEATHER_ATTRIBUTES.every((attr) =>
+    selectedKnownNames.includes(attr)
+  );
+  const hasOverrides =
+    Object.keys(overrides.entity).length > 0 ||
+    Object.keys(overrides.label).length > 0 ||
+    Object.keys(overrides.icon).length > 0;
+
+  if (customItems.length === 0 && !hasOverrides && allKnownSelected) {
+    return true;
+  }
+
+  const known: (string | CurrentWeatherAttributeConfig)[] =
+    selectedKnownNames.map((name) => {
+      const e = overrides.entity[name];
+      const l = overrides.label[name];
+      const i = overrides.icon[name];
+      if (e || l || i) {
+        return {
+          name: name as CurrentWeatherAttributes,
+          ...(e ? { entity: e } : {}),
+          ...(l ? { label: l } : {}),
+          ...(i ? { icon: i } : {}),
+        };
+      }
+      return name;
+    });
+
+  return [...known, ...customItems];
+};
+
 const moveDottedKeysToNested = (obj: Record<string, any>) => {
   const result: Record<string, any> = { ...obj };
 
@@ -860,7 +970,7 @@ const moveDottedKeysToNested = (obj: Record<string, any>) => {
   return result;
 };
 
-const denormalizeConfig = (obj: Record<string, any>) => {
+export const denormalizeConfig = (obj: Record<string, any>) => {
   const result = flattenNestedKeys(obj);
 
   result.forecast_mode =
@@ -885,21 +995,35 @@ const denormalizeConfig = (obj: Record<string, any>) => {
     result["current.show_attributes"] = [...CURRENT_WEATHER_ATTRIBUTES];
   }
 
-  // Handle show_attributes that may contain objects with entity references
+  // Handle show_attributes: extract only KNOWN items for the multiselect;
+  // flatten per-attribute entity/label/icon overrides for the form fields.
+  // Custom items (entity-only or arbitrary-name) are preserved via _valueChanged
+  // reading this._config directly — do NOT put them in normalizedAttrs.
   const showAttrs = result["current.show_attributes"];
   if (Array.isArray(showAttrs)) {
-    // Extract attribute entities and normalize the array
     const normalizedAttrs: string[] = [];
 
     for (const item of showAttrs) {
       if (typeof item === "string") {
-        normalizedAttrs.push(item);
-      } else if (typeof item === "object" && item.name) {
-        normalizedAttrs.push(item.name);
-        // Store entity in flattened format for the form
-        if (item.entity) {
-          result[`current.attribute_entity_${item.name}`] = item.entity;
+        if (isKnownAttribute(item)) {
+          normalizedAttrs.push(item);
         }
+        // unknown string custom items: skip (preserved via this._config)
+      } else if (typeof item === "object" && item !== null) {
+        const cfg = item as CurrentWeatherAttributeConfig;
+        if (isKnownAttribute(cfg.name)) {
+          normalizedAttrs.push(cfg.name);
+          if (cfg.entity) {
+            result[`current.attribute_entity_${cfg.name}`] = cfg.entity;
+          }
+          if (cfg.label) {
+            result[`current.attribute_label_${cfg.name}`] = cfg.label;
+          }
+          if (cfg.icon) {
+            result[`current.attribute_icon_${cfg.name}`] = cfg.icon;
+          }
+        }
+        // custom object items: skip (preserved via this._config)
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,8 +63,13 @@ export const DEFAULT_CHART_ATTRIBUTE: ChartAttributes =
   "temperature_and_precipitation";
 
 export interface CurrentWeatherAttributeConfig {
-  name: CurrentWeatherAttributes;
+  // Optional: an item may be a known weather attribute (name) and/or a custom
+  // entity source (entity). At least one must be present to render. An
+  // entity-only item displays that entity's state as an arbitrary attribute.
+  name?: CurrentWeatherAttributes | (string & {});
   entity?: string;
+  label?: string;
+  icon?: string;
 }
 
 export type WeatherEffect = (typeof WEATHER_EFFECTS)[number];
@@ -104,7 +109,7 @@ export interface WeatherForecastCardCurrentConfig {
     | CurrentWeatherAttributeConfig
     | (CurrentWeatherAttributes | CurrentWeatherAttributeConfig)[];
   temperature_precision?: number;
-  secondary_info_attribute?: CurrentWeatherAttributes;
+  secondary_info_attribute?: CurrentWeatherAttributes | CurrentWeatherAttributeConfig;
   temperature_entity?: string;
 }
 

--- a/test/current-weather-attributes.test.ts
+++ b/test/current-weather-attributes.test.ts
@@ -179,6 +179,40 @@ describe("wfc-current-weather attributes", () => {
 
     expect(values).toContain("8,1 m/s");
   });
+
+  it("ignores null and empty placeholder items in show_attributes", async () => {
+    // The HA editor inserts a null placeholder when a new list item is added,
+    // before a value is chosen. These must not crash the render.
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: [
+              "wind_speed",
+              null,
+              {},
+            ] as unknown as CurrentWeatherAttributeConfig[],
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes");
+    expect(attrEl).not.toBeNull();
+
+    const items = attrEl?.querySelectorAll(".wfc-current-attribute");
+    expect(items?.length).toBe(1);
+
+    const value = attrEl!.querySelector(
+      ".wfc-current-attribute-value"
+    )?.textContent;
+    expect(value?.trim()).toBe("5 m/s");
+  });
 });
 
 describe("secondary_info_attribute", () => {
@@ -731,6 +765,50 @@ describe("custom entity attributes", () => {
       ".wfc-current-attribute-value"
     )?.textContent;
     expect(value?.trim()).toBe("75 %");
+  });
+
+  it("renders entity-only items (no name) from the entity state", async () => {
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: [
+              { entity: "sensor.custom_humidity" },
+              {
+                entity: "sensor.custom_pressure",
+                label: "Outside",
+                icon: "mdi:abacus",
+              },
+            ] as CurrentWeatherAttributeConfig[],
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes");
+    expect(attrEl).not.toBeNull();
+
+    const items = attrEl?.querySelectorAll(".wfc-current-attribute");
+    expect(items?.length).toBe(2);
+
+    const labels = Array.from(
+      attrEl!.querySelectorAll(".wfc-current-attribute-name")
+    ).map((node) => node.textContent?.trim());
+    const values = Array.from(
+      attrEl!.querySelectorAll(".wfc-current-attribute-value")
+    ).map((node) => node.textContent?.trim());
+
+    // entity-only with no label falls back to the entity friendly_name
+    expect(labels[0]).toBe("Custom Humidity Sensor");
+    expect(values[0]).toBe("75 %");
+    // explicit label override works on an entity-only item
+    expect(labels[1]).toBe("Outside");
+    expect(values[1]).toBe("1025 hPa");
   });
 
   it("skips attribute when custom entity is unavailable", async () => {

--- a/test/weather-forecast-card-editor.test.ts
+++ b/test/weather-forecast-card-editor.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+import { CURRENT_WEATHER_ATTRIBUTES } from "../src/types";
+import {
+  isKnownAttribute,
+  extractCustomAttributes,
+  buildShowAttributes,
+  denormalizeConfig,
+} from "../src/editor/weather-forecast-card-editor";
+
+// Worked example config used across multiple tests
+const workedExampleShowAttributes = [
+  { entity: "sensor.time" },
+  "wind_speed",
+  { entity: "sensor.wash", icon: "mdi:abacus", label: "kokkeli" },
+  { name: "humidity", entity: "sensor.my_hum", label: "Hum" },
+];
+
+const workedExampleConfig = {
+  type: "custom:weather-forecast-card" as const,
+  entity: "weather.demo",
+  current: {
+    show_attributes: workedExampleShowAttributes,
+  },
+};
+
+describe("isKnownAttribute", () => {
+  it("returns true for a known attribute", () => {
+    expect(isKnownAttribute("humidity")).toBe(true);
+    expect(isKnownAttribute("wind_speed")).toBe(true);
+    expect(isKnownAttribute("cloud_coverage")).toBe(true);
+  });
+
+  it("returns false for an unknown attribute name", () => {
+    expect(isKnownAttribute("soil_moisture")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isKnownAttribute(undefined)).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect(isKnownAttribute(42)).toBe(false);
+    expect(isKnownAttribute(null)).toBe(false);
+    expect(isKnownAttribute({})).toBe(false);
+  });
+});
+
+describe("extractCustomAttributes", () => {
+  it("returns entity-only items as-is", () => {
+    const result = extractCustomAttributes([{ entity: "sensor.time" }]);
+    expect(result).toEqual([{ entity: "sensor.time" }]);
+  });
+
+  it("returns arbitrary-name items as-is", () => {
+    const result = extractCustomAttributes([
+      { entity: "sensor.wash", icon: "mdi:abacus", label: "kokkeli" },
+    ]);
+    expect(result).toEqual([
+      { entity: "sensor.wash", icon: "mdi:abacus", label: "kokkeli" },
+    ]);
+  });
+
+  it("returns custom items from the worked example", () => {
+    const result = extractCustomAttributes(workedExampleShowAttributes);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ entity: "sensor.time" });
+    expect(result).toContainEqual({
+      entity: "sensor.wash",
+      icon: "mdi:abacus",
+      label: "kokkeli",
+    });
+    // known items must NOT appear
+    expect(result.some((c) => c.name === "humidity")).toBe(false);
+    expect(result.some((c) => (c as { name?: string }).name === "wind_speed")).toBe(false);
+  });
+
+  it("wraps unknown string items as objects with name", () => {
+    const result = extractCustomAttributes(["soil_moisture"]);
+    expect(result).toEqual([{ name: "soil_moisture" }]);
+  });
+
+  it("does NOT wrap known string items", () => {
+    const result = extractCustomAttributes(["humidity", "wind_speed"]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns [] for true", () => {
+    expect(extractCustomAttributes(true)).toEqual([]);
+  });
+
+  it("returns [] for undefined", () => {
+    expect(extractCustomAttributes(undefined)).toEqual([]);
+  });
+
+  it("returns [] for a plain string", () => {
+    expect(extractCustomAttributes("humidity")).toEqual([]);
+  });
+
+  it("drops null entries in arrays", () => {
+    const result = extractCustomAttributes([null, { entity: "sensor.time" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ entity: "sensor.time" });
+  });
+});
+
+describe("denormalizeConfig", () => {
+  it("extracts only known attributes into current.show_attributes", () => {
+    const form = denormalizeConfig(workedExampleConfig);
+    expect(form["current.show_attributes"]).toEqual(["wind_speed", "humidity"]);
+  });
+
+  it("flattens humidity entity and label overrides", () => {
+    const form = denormalizeConfig(workedExampleConfig);
+    expect(form["current.attribute_entity_humidity"]).toBe("sensor.my_hum");
+    expect(form["current.attribute_label_humidity"]).toBe("Hum");
+  });
+
+  it("does not include entity-only items in the form's show_attributes", () => {
+    const form = denormalizeConfig(workedExampleConfig);
+    const attrs: string[] = form["current.show_attributes"];
+    // sensor.time and sensor.wash are entity-only — must not appear
+    expect(attrs).not.toContain("sensor.time");
+    expect(attrs).not.toContain("sensor.wash");
+  });
+
+  it("does not create form keys for custom (entity-only) items", () => {
+    const form = denormalizeConfig(workedExampleConfig);
+    // No flat key for entity-only items
+    const keys = Object.keys(form);
+    expect(keys.some((k) => k.includes("sensor.time"))).toBe(false);
+    expect(keys.some((k) => k.includes("sensor.wash"))).toBe(false);
+  });
+
+  it("expands true to all 10 known attributes", () => {
+    const form = denormalizeConfig({
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      current: { show_attributes: true },
+    });
+    expect(form["current.show_attributes"]).toEqual([
+      ...CURRENT_WEATHER_ATTRIBUTES,
+    ]);
+  });
+});
+
+describe("buildShowAttributes", () => {
+  it("returns true when all 10 known attributes selected, no overrides, no custom", () => {
+    const result = buildShowAttributes(
+      [...CURRENT_WEATHER_ATTRIBUTES],
+      { entity: {}, label: {}, icon: {} },
+      []
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns mixed array with entity+label override for known and custom items appended", () => {
+    const customItems = extractCustomAttributes(workedExampleShowAttributes);
+    const result = buildShowAttributes(
+      ["wind_speed", "humidity"],
+      {
+        entity: { humidity: "sensor.my_hum" },
+        label: { humidity: "Hum" },
+        icon: {},
+      },
+      customItems
+    );
+
+    expect(Array.isArray(result)).toBe(true);
+    const arr = result as (string | { name?: string; entity?: string; label?: string; icon?: string })[];
+
+    // wind_speed has no overrides → remains a string
+    expect(arr).toContain("wind_speed");
+
+    // humidity has overrides → becomes an object
+    const humidityItem = arr.find(
+      (item) => typeof item === "object" && item.name === "humidity"
+    ) as { name: string; entity: string; label: string } | undefined;
+    expect(humidityItem).toBeDefined();
+    expect(humidityItem?.entity).toBe("sensor.my_hum");
+    expect(humidityItem?.label).toBe("Hum");
+
+    // custom items appended at the end
+    expect(arr).toContainEqual({ entity: "sensor.time" });
+    expect(arr).toContainEqual({
+      entity: "sensor.wash",
+      icon: "mdi:abacus",
+      label: "kokkeli",
+    });
+  });
+
+  it("places known items before custom items", () => {
+    const customItems = [{ entity: "sensor.time" }];
+    const result = buildShowAttributes(
+      ["humidity"],
+      { entity: {}, label: {}, icon: {} },
+      customItems
+    ) as unknown[];
+    const humidityIdx = result.indexOf("humidity");
+    const customIdx = result.findIndex(
+      (item) =>
+        typeof item === "object" &&
+        (item as { entity?: string }).entity === "sensor.time"
+    );
+    expect(humidityIdx).toBeLessThan(customIdx);
+  });
+
+  it("does not return true when there are custom items even if all known are selected", () => {
+    const result = buildShowAttributes(
+      [...CURRENT_WEATHER_ATTRIBUTES],
+      { entity: {}, label: {}, icon: {} },
+      [{ entity: "sensor.time" }]
+    );
+    expect(result).not.toBe(true);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("does not return true when there are overrides even if all known are selected", () => {
+    const result = buildShowAttributes(
+      [...CURRENT_WEATHER_ATTRIBUTES],
+      { entity: { humidity: "sensor.my_hum" }, label: {}, icon: {} },
+      []
+    );
+    expect(result).not.toBe(true);
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+describe("round-trip preservation", () => {
+  it("preserves entity-only custom items through denormalizeConfig + buildShowAttributes", () => {
+    // Step 1: denormalize the config → get the form data
+    const formData = denormalizeConfig(workedExampleConfig);
+
+    // Step 2: derive selectedKnownNames from form
+    const selectedKnownNames: string[] = formData["current.show_attributes"];
+
+    // Step 3: collect override maps from flat form fields
+    const entityOverrides: Record<string, string> = {};
+    const labelOverrides: Record<string, string> = {};
+    const iconOverrides: Record<string, string> = {};
+
+    for (const key of Object.keys(formData)) {
+      if (key.startsWith("current.attribute_entity_")) {
+        const attr = key.replace("current.attribute_entity_", "");
+        entityOverrides[attr] = formData[key];
+      } else if (key.startsWith("current.attribute_label_")) {
+        const attr = key.replace("current.attribute_label_", "");
+        labelOverrides[attr] = formData[key];
+      } else if (key.startsWith("current.attribute_icon_")) {
+        const attr = key.replace("current.attribute_icon_", "");
+        iconOverrides[attr] = formData[key];
+      }
+    }
+
+    // Step 4: extract custom items from the original config
+    const customItems = extractCustomAttributes(
+      workedExampleConfig.current.show_attributes
+    );
+
+    // Step 5: rebuild
+    const rebuilt = buildShowAttributes(
+      selectedKnownNames,
+      { entity: entityOverrides, label: labelOverrides, icon: iconOverrides },
+      customItems
+    );
+
+    expect(Array.isArray(rebuilt)).toBe(true);
+    const arr = rebuilt as unknown[];
+
+    // Entity-only custom items must survive
+    expect(arr).toContainEqual({ entity: "sensor.time" });
+    expect(arr).toContainEqual({
+      entity: "sensor.wash",
+      icon: "mdi:abacus",
+      label: "kokkeli",
+    });
+
+    // Known items must survive
+    expect(arr).toContain("wind_speed");
+    const humidityItem = arr.find(
+      (item) =>
+        typeof item === "object" &&
+        (item as { name?: string }).name === "humidity"
+    ) as { name: string; entity: string; label: string } | undefined;
+    expect(humidityItem).toBeDefined();
+    expect(humidityItem?.entity).toBe("sensor.my_hum");
+    expect(humidityItem?.label).toBe("Hum");
+  });
+});

--- a/test/weather-forecast-card-editor.test.ts
+++ b/test/weather-forecast-card-editor.test.ts
@@ -3,6 +3,7 @@ import { CURRENT_WEATHER_ATTRIBUTES } from "../src/types";
 import {
   isKnownAttribute,
   extractCustomAttributes,
+  extractKnownItems,
   buildShowAttributes,
   denormalizeConfig,
 } from "../src/editor/weather-forecast-card-editor";
@@ -284,5 +285,87 @@ describe("round-trip preservation", () => {
     expect(humidityItem).toBeDefined();
     expect(humidityItem?.entity).toBe("sensor.my_hum");
     expect(humidityItem?.label).toBe("Hum");
+  });
+});
+
+describe("extractKnownItems", () => {
+  it("expands true to all 10 known attributes", () => {
+    expect(extractKnownItems(true)).toEqual([...CURRENT_WEATHER_ATTRIBUTES]);
+  });
+
+  it("returns known strings and known objects, excludes custom", () => {
+    const result = extractKnownItems(workedExampleShowAttributes);
+    expect(result).toHaveLength(2);
+    expect(result).toContain("wind_speed");
+    expect(result).toContainEqual({
+      name: "humidity",
+      entity: "sensor.my_hum",
+      label: "Hum",
+    });
+    expect(
+      result.some(
+        (item) =>
+          typeof item === "object" &&
+          (item as { entity?: string }).entity === "sensor.time"
+      )
+    ).toBe(false);
+  });
+
+  it("returns the single known string", () => {
+    expect(extractKnownItems("humidity")).toEqual(["humidity"]);
+  });
+
+  it("returns [] for an unknown string, false and undefined", () => {
+    expect(extractKnownItems("soil_moisture")).toEqual([]);
+    expect(extractKnownItems(false)).toEqual([]);
+    expect(extractKnownItems(undefined)).toEqual([]);
+  });
+
+  it("drops null entries", () => {
+    expect(extractKnownItems([null, "humidity"])).toEqual(["humidity"]);
+  });
+});
+
+describe("custom entity attributes editor merge (add/remove)", () => {
+  it("partitions every item into exactly one of known or custom", () => {
+    const known = extractKnownItems(workedExampleShowAttributes);
+    const custom = extractCustomAttributes(workedExampleShowAttributes);
+    expect(known.length + custom.length).toBe(
+      workedExampleShowAttributes.length
+    );
+  });
+
+  it("adding a blank custom row keeps known and existing custom items", () => {
+    const known = extractKnownItems(workedExampleShowAttributes);
+    const custom = [
+      ...extractCustomAttributes(workedExampleShowAttributes),
+      {},
+    ];
+    const merged = [...known, ...custom];
+
+    expect(merged).toContain("wind_speed");
+    expect(merged).toContainEqual({ entity: "sensor.time" });
+    expect(merged[merged.length - 1]).toEqual({});
+  });
+
+  it("removing a custom row keeps the rest intact", () => {
+    const known = extractKnownItems(workedExampleShowAttributes);
+    const custom = extractCustomAttributes(workedExampleShowAttributes);
+    custom.splice(0, 1); // remove sensor.time
+    const merged = [...known, ...custom];
+
+    expect(
+      merged.some(
+        (item) =>
+          typeof item === "object" &&
+          (item as { entity?: string }).entity === "sensor.time"
+      )
+    ).toBe(false);
+    expect(merged).toContain("wind_speed");
+    expect(merged).toContainEqual({
+      entity: "sensor.wash",
+      icon: "mdi:abacus",
+      label: "kokkeli",
+    });
   });
 });

--- a/test/weather-forecast-card-editor.test.ts
+++ b/test/weather-forecast-card-editor.test.ts
@@ -5,6 +5,7 @@ import {
   extractCustomAttributes,
   extractKnownItems,
   buildShowAttributes,
+  rebuildShowAttributesWithCustom,
   denormalizeConfig,
 } from "../src/editor/weather-forecast-card-editor";
 
@@ -363,6 +364,49 @@ describe("custom entity attributes editor merge (add/remove)", () => {
     ).toBe(false);
     expect(merged).toContain("wind_speed");
     expect(merged).toContainEqual({
+      entity: "sensor.wash",
+      icon: "mdi:abacus",
+      label: "kokkeli",
+    });
+  });
+});
+
+describe("rebuildShowAttributesWithCustom", () => {
+  it("restores the compact `true` form after adding then removing a custom row", () => {
+    // Start from "all known attributes".
+    let showAttributes: unknown = true;
+
+    // Add a blank custom row.
+    showAttributes = rebuildShowAttributesWithCustom(showAttributes, [
+      ...extractCustomAttributes(showAttributes),
+      {},
+    ]);
+    expect(Array.isArray(showAttributes)).toBe(true);
+
+    // Remove it again — should canonicalize back to `true`, not an expanded array.
+    showAttributes = rebuildShowAttributesWithCustom(
+      showAttributes,
+      extractCustomAttributes(showAttributes).filter((_, i) => i !== 0)
+    );
+    expect(showAttributes).toBe(true);
+  });
+
+  it("preserves known overrides and custom items", () => {
+    const result = rebuildShowAttributesWithCustom(
+      workedExampleShowAttributes,
+      extractCustomAttributes(workedExampleShowAttributes)
+    );
+
+    expect(Array.isArray(result)).toBe(true);
+    const arr = result as unknown[];
+    expect(arr).toContain("wind_speed");
+    expect(arr).toContainEqual({
+      name: "humidity",
+      entity: "sensor.my_hum",
+      label: "Hum",
+    });
+    expect(arr).toContainEqual({ entity: "sensor.time" });
+    expect(arr).toContainEqual({
       entity: "sensor.wash",
       icon: "mdi:abacus",
       label: "kokkeli",


### PR DESCRIPTION
Closes #137

Adds full customization of the current weather attributes.

**Configuration**

- Source any attribute value from a separate entity (extends the existing per-attribute override).
- Custom `label` and `icon` per attribute.
- Arbitrary entity-only attributes: display any entity's state, even if it is not a standard weather attribute. Label defaults to the entity friendly name unless overridden.
- `secondary_info_attribute` can also read from a custom entity.

`name` is now optional on attribute config objects; an item needs a `name`, an `entity`, or both.

**Editor**

- Optional label and icon fields for each selected standard attribute.
- New "Custom entity attributes" section to add and remove arbitrary entity attributes, styled to match the existing expandable sections.
- Round-trip safe: known and custom items are preserved when editing in the UI, so opening the visual editor never drops YAML-authored custom attributes.

**Docs and tests**

- README updated with the object format (`name`/`entity`/`label`/`icon`), examples, and editor usage.
- Unit tests cover entity-only rendering, the config/editor round-trip, and the known/custom partition and merge.

