### PR TITLE
feat: respect HA Sections grid row height

### DIFF
--- a/src/hass/types.ts
+++ b/src/hass/types.ts
@@ -33,3 +33,17 @@ export const isSubscriptionNotFoundError = (
     (error as { code: unknown }).code === "not_found"
   );
 };
+
+/**
+ * Grid sizing options reported to Home Assistant via `getGridOptions()`.
+ * Mirrors the `LovelaceGridOptions` type in the HA frontend and is used by the
+ * Sections view to size and snap the card to whole grid rows.
+ */
+export interface LovelaceGridOptions {
+  columns?: number | "full";
+  rows?: number | "auto";
+  max_columns?: number;
+  min_columns?: number;
+  min_rows?: number;
+  max_rows?: number;
+}

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -96,7 +96,9 @@
     --weather-forecast-card-min-item-width-chart,
     55px
   );
-  --forecast-item-width: var(--wfc-min-item-width-simple); /* Initial minimum value. Updated in JS */
+  --forecast-item-width: var(
+    --wfc-min-item-width-simple
+  ); /* Initial minimum value. Updated in JS */
   --forecast-item-gap: 0px; /* Initial minimum value. Updated in JS */
   --forecast-precipitation-bar-max-height: calc(
     var(--ha-font-size-s, 12px) + 2px
@@ -130,8 +132,11 @@
 ha-card {
   position: relative;
   box-sizing: border-box;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: 100%;
+  height: 100%;
   min-width: 0;
   padding: var(--card-padding, 16px);
 }

--- a/src/weather-forecast-card.ts
+++ b/src/weather-forecast-card.ts
@@ -7,6 +7,7 @@ import {
   actionHandler,
   isInvalidEntityIdError,
   isSubscriptionNotFoundError,
+  LovelaceGridOptions,
 } from "./hass";
 import {
   ForecastActionEvent,
@@ -175,6 +176,82 @@ export class WeatherForecastCard extends LitElement {
 
     this.config = merge({}, DEFAULT_CONFIG, migratedConfig);
     this._currentForecastType = this.config.default_forecast || "daily";
+  }
+
+  /**
+   * Reports sizing to Home Assistant's Sections view so the card snaps to whole
+   * grid rows instead of taking an arbitrary fractional height.
+   *
+   * Row counts are derived from the enabled blocks; the content is vertically
+   * centered (see CSS) when the user sizes the card taller than it needs, so a
+   * slightly generous estimate only adds whitespace rather than clipping.
+   */
+  public getGridOptions(): LovelaceGridOptions {
+    const { rows, minRows, minColumns } = this.computeRowSizing();
+
+    return {
+      columns: 12,
+      rows,
+      min_rows: minRows,
+      min_columns: minColumns,
+    };
+  }
+
+  /**
+   * Reports sizing for the legacy masonry view (units of ~50px). Reuses the same
+   * block accounting as {@link getGridOptions}.
+   */
+  public getCardSize(): number {
+    return this.computeRowSizing().rows;
+  }
+
+  /**
+   * Derives the card's grid sizing from the enabled blocks (current weather and
+   * the simple/chart forecast). Pure function of the config with no `hass`/DOM
+   * dependency, so it is safe to call before the first render.
+   */
+  private computeRowSizing(): {
+    rows: number;
+    minRows: number;
+    minColumns: number;
+  } {
+    const showCurrent = this.config?.show_current !== false;
+    const showForecast = this.config?.show_forecast !== false;
+    const isChart = this.config?.forecast?.mode === ForecastMode.Chart;
+
+    // Base allowance for card padding and the gap between blocks.
+    let rows = 1;
+    let minRows = 1;
+
+    if (showCurrent) {
+      // Conditions icon + name + temperature.
+      rows += 2;
+      minRows += 2;
+
+      // The optional attribute list adds a variable amount of height; reserve a
+      // little extra so the default size does not clip a typical attribute list.
+      if (this.config?.current?.show_attributes) {
+        rows += 1;
+      }
+    }
+
+    if (showForecast) {
+      if (isChart) {
+        // Optional settings bar + 130px chart + header/footer labels.
+        rows += 3;
+        minRows += 3;
+      } else {
+        // Simple forecast column (time + icon + temperature + precipitation).
+        rows += 2;
+        minRows += 2;
+      }
+    }
+
+    return {
+      rows,
+      minRows,
+      minColumns: showCurrent && showForecast ? 6 : 4,
+    };
   }
 
   public connectedCallback(): void {

--- a/test/grid-options.test.ts
+++ b/test/grid-options.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { WeatherForecastCard } from "../src/weather-forecast-card";
+import { ForecastMode, WeatherForecastCardConfig } from "../src/types";
+
+import "../src/index";
+
+function createCard(
+  config: Partial<WeatherForecastCardConfig> = {}
+): WeatherForecastCard {
+  const card = document.createElement(
+    "weather-forecast-card"
+  ) as WeatherForecastCard;
+
+  card.setConfig({
+    type: "custom:weather-forecast-card",
+    entity: "weather.demo",
+    ...config,
+  } as WeatherForecastCardConfig);
+
+  return card;
+}
+
+describe("weather-forecast-card grid options", () => {
+  it("reports a 12-column grid with integer rows so it snaps in Sections view", () => {
+    const options = createCard().getGridOptions();
+
+    expect(options.columns).toBe(12);
+    expect(Number.isInteger(options.rows)).toBe(true);
+    expect(options.rows).not.toBe("auto");
+  });
+
+  it("never reports a minimum larger than the default rows", () => {
+    const configs: Partial<WeatherForecastCardConfig>[] = [
+      {},
+      { show_current: false },
+      { show_forecast: false },
+      { forecast: { mode: ForecastMode.Chart } },
+      { current: { show_attributes: true } },
+    ];
+
+    for (const config of configs) {
+      const options = createCard(config).getGridOptions();
+      expect(options.min_rows).toBeLessThanOrEqual(options.rows as number);
+    }
+  });
+
+  it("requires more rows for the taller chart forecast than the simple forecast", () => {
+    const simple = createCard({
+      forecast: { mode: ForecastMode.Simple },
+    }).getGridOptions();
+    const chart = createCard({
+      forecast: { mode: ForecastMode.Chart },
+    }).getGridOptions();
+
+    expect((chart.rows as number)).toBeGreaterThan(simple.rows as number);
+  });
+
+  it("reserves extra height when current attributes are shown", () => {
+    const without = createCard({
+      current: { show_attributes: false },
+    }).getGridOptions();
+    const withAttrs = createCard({
+      current: { show_attributes: true },
+    }).getGridOptions();
+
+    expect((withAttrs.rows as number)).toBeGreaterThan(without.rows as number);
+  });
+
+  it("drops a block's rows when that block is hidden", () => {
+    const both = createCard().getGridOptions();
+    const currentOnly = createCard({ show_forecast: false }).getGridOptions();
+    const forecastOnly = createCard({ show_current: false }).getGridOptions();
+
+    expect((currentOnly.rows as number)).toBeLessThan(both.rows as number);
+    expect((forecastOnly.rows as number)).toBeLessThan(both.rows as number);
+  });
+
+  it("widens the minimum columns only when both blocks are shown", () => {
+    expect(createCard().getGridOptions().min_columns).toBe(6);
+    expect(
+      createCard({ show_forecast: false }).getGridOptions().min_columns
+    ).toBe(4);
+    expect(
+      createCard({ show_current: false }).getGridOptions().min_columns
+    ).toBe(4);
+  });
+
+  it("exposes a masonry card size consistent with the grid rows", () => {
+    const card = createCard();
+
+    expect(card.getCardSize()).toBe(card.getGridOptions().rows);
+  });
+});


### PR DESCRIPTION
Closes #121.

The card declared no grid sizing, so in the Sections view Home Assistant fell back to `rows: "auto"` and gave it its exact natural height. It never snapped to whole rows, so it misaligned with neighbouring cards and pushed everything below it off the grid.

## Changes

- Implement `getGridOptions()` returning integer `rows`/`min_rows` and `min_columns` derived from the enabled blocks (current weather, simple vs chart forecast). Integer rows make the card snap to whole grid rows.
- Add `getCardSize()` for the legacy masonry view, reusing the same accounting.
- `ha-card` fills its grid cell and vertically centers its content, so dragging the card taller spaces it out instead of leaving a gap at the bottom — matching the built-in weather card. No-op in masonry/panel views where height is content-driven.

The row constants are intentionally slightly generous: since content is centered, over-estimating only adds whitespace, while under-estimating would clip.

## Tests

Adds `test/grid-options.test.ts` covering the block combinations and the snapping/min-bound invariants. Full suite green, lint clean, build clean.

## Out of scope

Stretching the chart to fill extra height (a fixed-size-tablet request from the issue thread) is a separate, opt-in follow-up that can build on this centering behaviour.