### PR TITLE
feat: add cloud condition effect for cloudy and partly cloudy

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,16 +313,17 @@ show_condition_effects: false
 
 ### Available Effects
 
-The card provides six different effect types that can be individually enabled or disabled:
+The card provides seven different effect types that can be individually enabled or disabled:
 
-| Effect Type     | Description                                                                                                                                                                               | Weather Conditions Applied              |
-| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
-| **`rain`**      | Animated raindrops falling with realistic wind drift. Droplet angle and speed adapt to wind conditions from weather data. Includes splash effects on landing.                             | `rainy`, `pouring`, `lightning-rainy`   |
-| **`snow`**      | Snowflakes falling with smooth sinusoidal drift patterns. Each flake follows a unique non-linear trajectory with varying sizes, opacity, and depths for realistic parallax effects.       | `snowy`, `snowy-rainy`                  |
-| **`lightning`** | Dramatic lightning flash sequences with multiple strikes and residual flickers, creating an authentic storm atmosphere.                                                                   | `lightning`, `lightning-rainy`          |
-| **`sky`**       | Visually pleasing gradient sky background that adapts to time of day if sun times are enabled.                                                                                            | `sunny`, `clear-night`                  |
-| **`sun`**       | Animated sun with rotating rays positioned at the top of the card. Creates a warm, dynamic daytime atmosphere. Automatically switches to moon effect after sunset if sun times are shown. | `sunny`                                 |
-| **`moon`**      | Crescent moon with animated twinkling stars scattered across the card. Stars have randomized positions, sizes, and twinkle animations for a serene nighttime atmosphere.                  | `clear-night`, `sunny` (with sun times) |
+| Effect Type     | Description                                                                                                                                                                               | Weather Conditions Applied                          |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| **`rain`**      | Animated raindrops falling with realistic wind drift. Droplet angle and speed adapt to wind conditions from weather data. Includes splash effects on landing.                             | `rainy`, `pouring`, `lightning-rainy`               |
+| **`snow`**      | Snowflakes falling with smooth sinusoidal drift patterns. Each flake follows a unique non-linear trajectory with varying sizes, opacity, and depths for realistic parallax effects.       | `snowy`, `snowy-rainy`                              |
+| **`lightning`** | Dramatic lightning flash sequences with multiple strikes and residual flickers, creating an authentic storm atmosphere.                                                                   | `lightning`, `lightning-rainy`                      |
+| **`sky`**       | Visually pleasing gradient sky background that adapts to time of day if sun times are enabled. Renders a soft overcast deck for `cloudy`.                                                  | `sunny`, `clear-night`, `cloudy`, `partlycloudy`    |
+| **`sun`**       | Animated sun with rotating rays positioned at the top of the card. Creates a warm, dynamic daytime atmosphere. Automatically switches to moon effect after sunset if sun times are shown. | `sunny`, `partlycloudy`                             |
+| **`moon`**      | Crescent moon with animated twinkling stars scattered across the card. Stars have randomized positions, sizes, and twinkle animations for a serene nighttime atmosphere.                  | `clear-night`, `partlycloudy`/`sunny` (with sun times) |
+| **`cloud`**     | Soft, realistic clouds drifting across the sky, their speed influenced by wind. `cloudy` shows a fuller grey deck over an overcast sky; `partlycloudy` shows a few lighter clouds alongside the sun or moon. Clouds are dimmed at night. | `cloudy`, `partlycloudy`                            |
 
 ## Custom Icons
 
@@ -439,6 +440,13 @@ Customize the appearance of animated weather effects when `show_condition_effect
 | `weather-forecast-card-effects-clear-night-sky-color`  | Light: `rgba(49, 46, 129, 0.7)` / Dark: `rgba(10, 15, 40, 0.85)`   | Night clear sky gradient primary color                 |
 | `weather-forecast-card-effects-clear-night-sky-accent` | Light: `rgba(88, 28, 135, 0.55)` / Dark: `rgba(20, 30, 80, 0.6)`   | Night clear sky gradient accent color                  |
 | `weather-forecast-card-effects-clear-night-horizon`    | Light: `rgba(236, 72, 153, 0.4)` / Dark: `rgba(40, 25, 100, 0.4)`  | Night clear sky gradient horizon color                 |
+| `weather-forecast-card-effects-overcast-sky-color`     | Light: `rgba(118, 132, 148, 0.42)` / Dark: `rgba(60, 70, 82, 0.55)` | Day overcast (`cloudy`) sky gradient primary color    |
+| `weather-forecast-card-effects-overcast-sky-accent`    | Light: `rgba(152, 165, 180, 0.34)` / Dark: `rgba(78, 89, 102, 0.45)` | Day overcast sky gradient accent color               |
+| `weather-forecast-card-effects-overcast-sky-horizon`   | Light: `rgba(196, 206, 216, 0.24)` / Dark: `rgba(102, 113, 126, 0.3)` | Day overcast sky gradient horizon color             |
+| `weather-forecast-card-effects-overcast-night-color`   | Light: `rgba(38, 44, 56, 0.8)` / Dark: `rgba(16, 20, 28, 0.88)`    | Night overcast sky gradient primary color              |
+| `weather-forecast-card-effects-overcast-night-accent`  | Light: `rgba(55, 62, 76, 0.65)` / Dark: `rgba(30, 36, 47, 0.7)`    | Night overcast sky gradient accent color               |
+| `weather-forecast-card-effects-overcast-night-horizon` | Light: `rgba(78, 86, 100, 0.45)` / Dark: `rgba(48, 55, 68, 0.5)`   | Night overcast sky gradient horizon color              |
+| `weather-forecast-card-effects-cloud-color`            | Light: `#f4f7fb` / Dark: `#dfe6ee`                                 | Base color of the drifting clouds                      |
 
 > [!NOTE]
 > Weather effects variables support both light and dark themes. Colors automatically adjust based on your theme's dark mode setting, with separate default values optimized for each mode.

--- a/src/components/animation/wfc-animation-provider.ts
+++ b/src/components/animation/wfc-animation-provider.ts
@@ -12,6 +12,7 @@ import { getSuntimesInfo } from "../../helpers";
 import {
   ForecastAttribute,
   getMaxPrecipitationForUnit,
+  getNormalizedWindBearing,
   getNormalizedWindSpeed,
   getWeatherUnit,
   WeatherEntity,
@@ -22,6 +23,19 @@ const PRECIPITATION_INTENSITY_MEDIUM = 3;
 const WIND_SPEED_MS_MAX = 14;
 const SNOW_MAX_PARTICLES = 75;
 const RAIN_MAX_PARTICLES = 75;
+const CLOUD_COUNT_OVERCAST = 4;
+const CLOUD_COUNT_PARTLY = 3;
+// Depth layers for parallax: clouds are split across these, each drifting at its
+// own speed (far = slower, near = faster) for a sense of depth.
+const CLOUD_DEPTH_LAYERS = 2;
+// Drift-duration multiplier per layer (index 0 = far/slow, last = near/fast).
+const CLOUD_LAYER_SPEED = [1.45, 0.7];
+// Seconds for a cloud layer to drift one card-width. Calm skies drift slowly,
+// windy skies faster.
+const CLOUD_DRIFT_DURATION_CALM_S = 90;
+const CLOUD_DRIFT_DURATION_WINDY_S = 50;
+// Minimum horizontal drift so clouds keep moving gently in calm or N-S winds.
+const CLOUD_DRIFT_BASELINE_FACTOR = 0.15;
 
 type BaseParticle = {
   x: string;
@@ -58,7 +72,24 @@ type SunRay = {
   width: string;
 };
 
-type WeatherParticle = Snowflake | Raindrop | Star | SunRay;
+type Cloud = {
+  type: "cloud";
+  variant: "white" | "grey";
+  night: boolean;
+  // Depth layer (0 = far) drives size, height, opacity and drift speed (parallax).
+  layer: number;
+  // Silhouette variant (1-5) and a horizontal flip give each cloud a distinct
+  // shape so the deck does not look like one repeated sprite.
+  shape: number;
+  flip: boolean;
+  x: string;
+  y: string;
+  width: string;
+  height: string;
+  opacity: string;
+};
+
+type WeatherParticle = Snowflake | Raindrop | Star | SunRay | Cloud;
 
 @customElement("wfc-animation-provider")
 export class WeatherAnimationProvider extends LitElement {
@@ -72,6 +103,12 @@ export class WeatherAnimationProvider extends LitElement {
 
   private _particles: WeatherParticle[] = [];
   private _resizeObserver?: ResizeObserver;
+
+  // Clouds are regenerated only when their defining inputs (coverage, day/night)
+  // change, not on every hass refresh, so a state update does not make the clouds
+  // jump to new random positions.
+  private _cloudParticles: Cloud[] = [];
+  private _cloudSignature?: string;
 
   static styles = styles;
 
@@ -144,6 +181,8 @@ export class WeatherAnimationProvider extends LitElement {
             return this.renderSnow();
           case "lightning":
             return this.renderLightning();
+          case "cloud":
+            return this.renderClouds();
           default:
             return nothing;
         }
@@ -168,6 +207,9 @@ export class WeatherAnimationProvider extends LitElement {
           break;
         case "sun":
           particles.push(...this.computeSunRayParticles());
+          break;
+        case "cloud":
+          particles.push(...this.getStableCloudParticles());
           break;
         default:
           break;
@@ -356,37 +398,53 @@ export class WeatherAnimationProvider extends LitElement {
     }
 
     const isClearState = state === "sunny" || state === "clear-night";
+    const isCloudy = state === "cloudy";
+    const isPartlyCloudy = state === "partlycloudy";
 
-    if (isClearState) {
+    // Sky backdrop for clear skies, partly cloudy and overcast `cloudy`.
+    if (isClearState || isPartlyCloudy || isCloudy) {
       if (isEnabled("sky")) effects.add("sky");
+    }
 
-      let isNight = state === "clear-night";
-
-      if (this.config.forecast?.show_sun_times) {
-        const suntimes = getSuntimesInfo(this.hass, new Date());
-        if (suntimes?.isNightTime) {
-          isNight = true;
-        }
-      }
-
-      if (isNight) {
+    // Sun or moon for clear skies and partly cloudy. Fully overcast `cloudy`
+    // hides the celestial body behind the cloud deck.
+    if (isClearState || isPartlyCloudy) {
+      if (this.isNightTime()) {
         if (isEnabled("moon")) effects.add("moon");
       } else {
         if (isEnabled("sun")) effects.add("sun");
       }
     }
 
+    // Drifting clouds for cloudy and partly cloudy.
+    if (isCloudy || isPartlyCloudy) {
+      if (isEnabled("cloud")) effects.add("cloud");
+    }
+
     return Array.from(effects);
   }
 
-  private renderSky() {
-    let isNight = this.weatherEntity.state === "clear-night";
-
-    if (this.config.forecast?.show_sun_times) {
-      isNight = getSuntimesInfo(this.hass, new Date())?.isNightTime ?? isNight;
+  /**
+   * Whether the card should render a night-time sky. `clear-night` is inherently
+   * night; other states rely on the sun times helper when those are enabled.
+   */
+  private isNightTime(): boolean {
+    if (this.weatherEntity?.state === "clear-night") {
+      return true;
     }
 
-    return html`<div class="${isNight ? "night-sky" : "sky"}"></div>`;
+    if (this.config.forecast?.show_sun_times) {
+      return getSuntimesInfo(this.hass, new Date())?.isNightTime ?? false;
+    }
+
+    return false;
+  }
+
+  private renderSky() {
+    const base = this.isNightTime() ? "night-sky" : "sky";
+    const isOvercast = this.weatherEntity?.state === "cloudy";
+
+    return html`<div class="${isOvercast ? `${base} overcast` : base}"></div>`;
   }
 
   private renderSun() {
@@ -420,6 +478,239 @@ export class WeatherAnimationProvider extends LitElement {
       height: `${random(100, 200)}`,
       width: `${random(5, 15)}`,
     }));
+  }
+
+  /**
+   * Returns cloud particles, reusing the previously generated set unless the
+   * clouds' defining inputs (coverage and day/night) have changed. This keeps the
+   * clouds stable across hass refreshes and container resizes instead of
+   * re-randomizing their positions on every update.
+   */
+  private getStableCloudParticles(): Cloud[] {
+    const isOvercast = this.weatherEntity?.state === "cloudy";
+    const signature = `${isOvercast ? "overcast" : "partly"}:${this.isNightTime()}`;
+
+    if (signature !== this._cloudSignature || !this._cloudParticles.length) {
+      this._cloudParticles = this.computeCloudParticles();
+      this._cloudSignature = signature;
+    }
+
+    return this._cloudParticles;
+  }
+
+  /**
+   * Computes drifting cloud sprites. Overcast (`cloudy`) produces a denser deck of
+   * larger, lower, grey clouds; partly cloudy produces fewer, smaller, lighter white
+   * clouds. Clouds are split across depth layers (far = small/faint/high, near =
+   * large/bold/low). Sizes are in pixels and `x` is a percentage of the card width
+   * so clouds scale naturally with the card. Drift speed is layer-wide (see
+   * renderClouds).
+   */
+  private computeCloudParticles(): Cloud[] {
+    const isOvercast = this.weatherEntity?.state === "cloudy";
+    const isNight = this.isNightTime();
+    const count = isOvercast ? CLOUD_COUNT_OVERCAST : CLOUD_COUNT_PARTLY;
+    const slot = 100 / count;
+    const clouds: Cloud[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const layer = i % CLOUD_DEPTH_LAYERS;
+      const isFar = layer === 0;
+
+      // Spread clouds across the width with jitter so the deck looks organic.
+      const x = i * slot + random(0, slot * 0.5) - slot * 0.25;
+
+      // Depth: far clouds are smaller, higher and fainter; near clouds are larger,
+      // lower and bolder. Wide ranges plus aspect-ratio jitter keep footprints
+      // varied rather than all sharing one shape.
+      const width = isOvercast
+        ? isFar
+          ? random(140, 200)
+          : random(215, 285)
+        : isFar
+          ? random(110, 165)
+          : random(180, 240);
+      const height = width * random(0.38, 0.5, true);
+      // Anchored toward the top so clouds hug the upper edge and leave the lower
+      // card area clear for the weather text.
+      const y = isOvercast
+        ? isFar
+          ? random(-26, -12)
+          : random(-16, -2)
+        : isFar
+          ? random(-10, 4)
+          : random(-4, 12);
+
+      // Overcast clouds stay translucent so the card surface shows through and
+      // text keeps its contrast; partly cloudy clouds are more solid. Far clouds
+      // are fainter than near ones, and night dims both into a subtle silhouette.
+      let opacity = isOvercast
+        ? isFar
+          ? random(0.36, 0.5, true)
+          : random(0.5, 0.64, true)
+        : isFar
+          ? random(0.68, 0.8, true)
+          : random(0.82, 0.92, true);
+      if (isNight) {
+        opacity *= 0.7;
+      }
+
+      clouds.push({
+        type: "cloud",
+        variant: isOvercast ? "grey" : "white",
+        night: isNight,
+        layer,
+        shape: random(1, 5),
+        flip: random(0, 1) === 1,
+        x: x.toFixed(1),
+        y: y.toFixed(0),
+        width: width.toFixed(0),
+        height: height.toFixed(0),
+        opacity: opacity.toFixed(2),
+      });
+    }
+
+    return clouds;
+  }
+
+  /**
+   * Drift direction and duration for a cloud layer, derived from the wind. Clouds
+   * move in the direction the wind blows: `wind_bearing` is the meteorological
+   * direction the wind comes *from*, so the rightward (eastward) component is
+   * `-sin(bearing)` — a wind from the west (270°) drifts clouds to the right, a
+   * wind from the east (90°) to the left. Horizontal speed scales with both wind
+   * speed and how east-west the wind blows, with a small baseline so clouds keep
+   * drifting gently in calm or purely north-south winds.
+   */
+  private computeCloudDrift(): { duration: number; driftRight: boolean } {
+    const forecast = this.currentForecast;
+    const speedMS = forecast
+      ? getNormalizedWindSpeed(this.hass, this.weatherEntity, forecast) || 0
+      : 0;
+    const speedFactor = Math.min(speedMS, WIND_SPEED_MS_MAX) / WIND_SPEED_MS_MAX;
+
+    // Signed horizontal component in [-1, 1]; positive points right (east).
+    // getNormalizedWindBearing handles numeric and cardinal (e.g. "NW") bearings.
+    const bearing = forecast ? getNormalizedWindBearing(forecast) : undefined;
+    const horizontal =
+      bearing !== undefined ? -Math.sin((bearing * Math.PI) / 180) : 0;
+
+    const horizontalFactor = Math.max(
+      CLOUD_DRIFT_BASELINE_FACTOR,
+      speedFactor * Math.abs(horizontal)
+    );
+
+    const duration =
+      CLOUD_DRIFT_DURATION_CALM_S -
+      horizontalFactor *
+        (CLOUD_DRIFT_DURATION_CALM_S - CLOUD_DRIFT_DURATION_WINDY_S);
+
+    return {
+      duration,
+      driftRight: horizontal >= 0,
+    };
+  }
+
+  private renderCloudFilter() {
+    // A single turbulence filter roughens the soft cloud silhouettes into organic,
+    // billowy edges. Defined in this shadow root so `filter: url(#wfc-cloud-rough)`
+    // resolves locally; if a browser cannot resolve it, the clouds gracefully fall
+    // back to the smooth gooey silhouette.
+    return html`
+      <svg class="cloud-defs" width="0" height="0" aria-hidden="true">
+        <defs>
+          <filter
+            id="wfc-cloud-rough"
+            x="-25%"
+            y="-25%"
+            width="150%"
+            height="150%"
+            color-interpolation-filters="sRGB"
+          >
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.012 0.018"
+              numOctaves="5"
+              seed="7"
+              stitchTiles="stitch"
+              result="noise"
+            ></feTurbulence>
+            <feDisplacementMap
+              in="SourceGraphic"
+              in2="noise"
+              scale="42"
+              xChannelSelector="R"
+              yChannelSelector="G"
+              result="disp"
+            ></feDisplacementMap>
+            <feGaussianBlur in="disp" stdDeviation="0.6"></feGaussianBlur>
+          </filter>
+        </defs>
+      </svg>
+    `;
+  }
+
+  private renderClouds() {
+    const clouds = this._particles.filter(
+      (p): p is Cloud => p.type === "cloud"
+    );
+
+    if (!clouds.length) return nothing;
+
+    const { duration, driftRight } = this.computeCloudDrift();
+
+    const renderCloud = (c: Cloud) => {
+      const classes = [
+        "cloud",
+        `cloud-shape-${c.shape}`,
+        c.variant === "grey" ? "grey" : "",
+        c.night ? "night" : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+
+      return html`<div
+        class="${classes}"
+        style="${styleMap({
+          left: `${c.x}%`,
+          top: `${c.y}px`,
+          width: `${c.width}px`,
+          height: `${c.height}px`,
+          opacity: c.opacity,
+          transform: c.flip ? "scaleX(-1)" : "none",
+        })}"
+      >
+        <div class="cloud-puffs"></div>
+        <div class="cloud-shade"></div>
+      </div>`;
+    };
+
+    // One drifting track per depth layer, each at its own parallax speed but the
+    // same wind direction. Each track renders its clouds twice inside a
+    // double-width track: translating by -50% slides the second copy into the
+    // first's start position for a seamless loop without needing the card width.
+    return html`
+      ${this.renderCloudFilter()}
+      ${Array.from({ length: CLOUD_DEPTH_LAYERS }, (_unused, layer) => {
+        const layerClouds = clouds.filter((c) => c.layer === layer);
+        if (!layerClouds.length) return nothing;
+
+        // Round to a coarse bucket so small wind fluctuations between refreshes do
+        // not change the duration and visibly nudge the running drift.
+        const layerDuration =
+          Math.round((duration * (CLOUD_LAYER_SPEED[layer] ?? 1)) / 5) * 5;
+
+        return html`<div
+          class="cloud-track ${driftRight ? "drift-right" : ""}"
+          style="${styleMap({ "--cloud-drift-duration": `${layerDuration}s` })}"
+        >
+          <div class="cloud-set">${layerClouds.map(renderCloud)}</div>
+          <div class="cloud-set cloud-set-second">
+            ${layerClouds.map(renderCloud)}
+          </div>
+        </div>`;
+      })}
+    `;
   }
 
   private renderSnow() {

--- a/src/components/animation/wfc-animation.css
+++ b/src/components/animation/wfc-animation.css
@@ -69,6 +69,31 @@
     --weather-forecast-card-effects-clear-night-horizon,
     rgba(236, 72, 153, 0.4)
   );
+  --overcast-sky-color: var(
+    --weather-forecast-card-effects-overcast-sky-color,
+    rgba(118, 132, 148, 0.42)
+  );
+  --overcast-sky-accent: var(
+    --weather-forecast-card-effects-overcast-sky-accent,
+    rgba(152, 165, 180, 0.34)
+  );
+  --overcast-sky-horizon: var(
+    --weather-forecast-card-effects-overcast-sky-horizon,
+    rgba(196, 206, 216, 0.24)
+  );
+  --overcast-night-color: var(
+    --weather-forecast-card-effects-overcast-night-color,
+    rgba(38, 44, 56, 0.8)
+  );
+  --overcast-night-accent: var(
+    --weather-forecast-card-effects-overcast-night-accent,
+    rgba(55, 62, 76, 0.65)
+  );
+  --overcast-night-horizon: var(
+    --weather-forecast-card-effects-overcast-night-horizon,
+    rgba(78, 86, 100, 0.45)
+  );
+  --cloud-color: var(--weather-forecast-card-effects-cloud-color, #f4f7fb);
 }
 
 :host(.dark) {
@@ -110,6 +135,31 @@
     --weather-forecast-card-effects-clear-night-horizon,
     rgba(40, 25, 100, 0.4)
   );
+  --overcast-sky-color: var(
+    --weather-forecast-card-effects-overcast-sky-color,
+    rgba(60, 70, 82, 0.55)
+  );
+  --overcast-sky-accent: var(
+    --weather-forecast-card-effects-overcast-sky-accent,
+    rgba(78, 89, 102, 0.45)
+  );
+  --overcast-sky-horizon: var(
+    --weather-forecast-card-effects-overcast-sky-horizon,
+    rgba(102, 113, 126, 0.3)
+  );
+  --overcast-night-color: var(
+    --weather-forecast-card-effects-overcast-night-color,
+    rgba(16, 20, 28, 0.88)
+  );
+  --overcast-night-accent: var(
+    --weather-forecast-card-effects-overcast-night-accent,
+    rgba(30, 36, 47, 0.7)
+  );
+  --overcast-night-horizon: var(
+    --weather-forecast-card-effects-overcast-night-horizon,
+    rgba(48, 55, 68, 0.5)
+  );
+  --cloud-color: var(--weather-forecast-card-effects-cloud-color, #dfe6ee);
 }
 
 /* Modern browsers with color-mix support */
@@ -232,6 +282,24 @@
   pointer-events: none;
 }
 
+/* Overcast deck for the `cloudy` condition (day) */
+.sky.overcast {
+  background: linear-gradient(
+    180deg,
+    var(--overcast-sky-color) 0%,
+    var(--overcast-sky-accent) 55%,
+    var(--overcast-sky-horizon) 100%
+  );
+}
+
+.sky.overcast::before {
+  background: radial-gradient(
+    circle at 50% 10%,
+    rgba(255, 255, 255, 0.18) 0%,
+    transparent 55%
+  );
+}
+
 .sun {
   position: absolute;
   top: calc(var(--sun-size) * -0.95);
@@ -307,6 +375,20 @@
   pointer-events: none;
 }
 
+/* Overcast deck for the `cloudy` condition (night) */
+.night-sky.overcast {
+  background: linear-gradient(
+    180deg,
+    var(--overcast-night-color) 0%,
+    var(--overcast-night-accent) 55%,
+    var(--overcast-night-horizon) 100%
+  );
+}
+
+.night-sky.overcast::before {
+  background: none;
+}
+
 .moon {
   position: absolute;
   top: calc(var(--moon-size) * -0.85);
@@ -328,6 +410,147 @@
   border-radius: 50%;
   animation: twinkle 3s ease-in-out infinite;
   box-shadow: 0 0 3px 1px var(--star-color);
+}
+
+/* ---- Clouds ----
+   A double-width track holds two identical cloud sets; translating it by -50%
+   slides the second copy into the first's start position for a seamless drift. */
+.cloud-defs {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+
+.cloud-track {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  z-index: 0;
+  animation: cloud-drift var(--cloud-drift-duration, 80s) linear infinite;
+  will-change: transform;
+}
+
+/* Wind blowing toward the east drifts the deck rightward (the track is two
+   identical tiles, so reversing the same keyframe stays seamless). */
+.cloud-track.drift-right {
+  animation-direction: reverse;
+}
+
+.cloud-set {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+
+.cloud-set-second {
+  left: 50%;
+}
+
+.cloud {
+  position: absolute;
+  /* Soft elliptical billows are merged into a cumulus silhouette by the child's
+     blur+contrast, then the edges are roughened by the SVG turbulence filter. */
+  filter: url(#wfc-cloud-rough);
+}
+
+/* Night clouds are dimmed so they read as a subtle silhouette, not bright puffs. */
+.cloud.night {
+  filter: url(#wfc-cloud-rough) brightness(0.5);
+}
+
+.cloud-puffs {
+  position: absolute;
+  inset: 0;
+  filter: blur(6px) contrast(22);
+}
+
+.cloud-puffs::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-repeat: no-repeat;
+}
+
+/* Five silhouette layouts (+ random horizontal flip in JS) keep clouds from
+   looking like one repeated sprite. */
+.cloud-shape-1 .cloud-puffs::before {
+  background:
+    radial-gradient(28% 42% at 22% 58%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(34% 60% at 42% 46%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(30% 50% at 62% 52%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(24% 38% at 80% 60%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(90% 26% at 50% 74%, var(--cloud-color) 0 60%, transparent 64%);
+}
+
+.cloud-shape-2 .cloud-puffs::before {
+  background:
+    radial-gradient(30% 55% at 28% 50%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(26% 44% at 50% 58%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(34% 60% at 70% 47%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(20% 32% at 90% 62%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(92% 24% at 50% 76%, var(--cloud-color) 0 60%, transparent 64%);
+}
+
+.cloud-shape-3 .cloud-puffs::before {
+  background:
+    radial-gradient(20% 34% at 14% 62%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(32% 64% at 35% 40%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(26% 48% at 56% 54%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(22% 40% at 75% 56%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(94% 24% at 50% 75%, var(--cloud-color) 0 60%, transparent 64%);
+}
+
+/* A compact, puffier two-lobe cloud. */
+.cloud-shape-4 .cloud-puffs::before {
+  background:
+    radial-gradient(34% 66% at 34% 44%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(38% 70% at 62% 42%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(22% 40% at 84% 58%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(74% 26% at 48% 76%, var(--cloud-color) 0 60%, transparent 64%);
+}
+
+/* A long, low bank with many small billows. */
+.cloud-shape-5 .cloud-puffs::before {
+  background:
+    radial-gradient(18% 32% at 12% 60%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(22% 44% at 30% 52%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(24% 46% at 48% 50%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(22% 42% at 66% 52%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(18% 34% at 84% 58%, var(--cloud-color) 0 60%, transparent 62%),
+    radial-gradient(96% 22% at 50% 76%, var(--cloud-color) 0 60%, transparent 64%);
+}
+
+.cloud.grey .cloud-puffs::before {
+  filter: brightness(0.86) saturate(0.55);
+}
+
+/* Volumetric shading: shadowed underside, highlighted top-left. */
+.cloud-shade {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      55% 45% at 50% 92%,
+      rgba(90, 100, 115, 0.5) 0%,
+      rgba(90, 100, 115, 0) 70%
+    ),
+    radial-gradient(
+      50% 45% at 38% 26%,
+      rgba(255, 255, 255, 0.85) 0%,
+      rgba(255, 255, 255, 0) 70%
+    );
+  mix-blend-mode: soft-light;
+}
+
+@keyframes cloud-drift {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
 }
 
 @keyframes twinkle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export const WEATHER_EFFECTS = [
   "sky",
   "moon",
   "sun",
+  "cloud",
 ] as const;
 
 export type CurrentWeatherAttributes =

--- a/test/weather-forecast-card-animations.test.ts
+++ b/test/weather-forecast-card-animations.test.ts
@@ -8,6 +8,8 @@ import {
   WeatherForecastCardConfig,
 } from "../src/types";
 import { WeatherForecastCard } from "../src/weather-forecast-card";
+import { WeatherAnimationProvider } from "../src/components/animation/wfc-animation-provider";
+import { ForecastAttribute, WeatherEntity } from "../src/data/weather";
 
 import "../src/index";
 
@@ -87,6 +89,25 @@ describe("weather-forecast-card-animations", () => {
       expect(
         queryAnimationAll(element, ".raindrop-path").length
       ).toBeGreaterThan(1);
+    });
+
+    it("should render clouds and an overcast sky for cloudy weather", async () => {
+      const element = await createFixture("cloudy", true);
+
+      expect(queryAnimationAll(element, ".cloud").length).toBeGreaterThan(0);
+      expect(queryAnimation(element, ".sky.overcast")).not.toBeNull();
+      // Fully overcast: no sun or moon behind the cloud deck.
+      expect(queryAnimation(element, ".sun")).toBeNull();
+      expect(queryAnimation(element, ".moon")).toBeNull();
+    });
+
+    it("should render clouds, sky and sun for partly cloudy weather", async () => {
+      const element = await createFixture("partlycloudy", true);
+
+      expect(queryAnimationAll(element, ".cloud").length).toBeGreaterThan(0);
+      expect(queryAnimation(element, ".sky")).not.toBeNull();
+      expect(queryAnimation(element, ".sky.overcast")).toBeNull();
+      expect(queryAnimation(element, ".sun")).not.toBeNull();
     });
   });
 
@@ -171,6 +192,26 @@ describe("weather-forecast-card-animations", () => {
         queryAnimationAll(element, ".raindrop-path").length
       ).toBeGreaterThan(1);
     });
+
+    it("should render clouds but no sky when only cloud is enabled", async () => {
+      const element = await createFixture("cloudy", ["cloud"]);
+
+      expect(queryAnimationAll(element, ".cloud").length).toBeGreaterThan(0);
+      expect(queryAnimation(element, ".sky")).toBeNull();
+    });
+
+    it("should render the overcast sky but no clouds when only sky is enabled", async () => {
+      const element = await createFixture("cloudy", ["sky"]);
+
+      expect(queryAnimation(element, ".sky.overcast")).not.toBeNull();
+      expect(queryAnimationAll(element, ".cloud").length).toBe(0);
+    });
+
+    it("should not render clouds for cloudy when cloud is not enabled", async () => {
+      const element = await createFixture("cloudy", ["rain", "snow"]);
+
+      expect(queryAnimationAll(element, ".cloud").length).toBe(0);
+    });
   });
 
   describe("combined effect scenarios", () => {
@@ -193,7 +234,94 @@ describe("weather-forecast-card-animations", () => {
       expect(queryAnimation(element, ".sun")).toBeNull();
     });
   });
+
+  describe("cloud stability", () => {
+    it("should not regenerate clouds when the weather entity refreshes", async () => {
+      const mockHass = new MockHass({ currentCondition: "cloudy" });
+      const hass = mockHass.getHass() as ExtendedHomeAssistant;
+      const entity = hass.states["weather.demo"] as WeatherEntity;
+      const config: WeatherForecastCardConfig = {
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+        show_condition_effects: true,
+        forecast: { show_sun_times: false },
+      };
+
+      const provider = await fixture<WeatherAnimationProvider>(
+        html`<wfc-animation-provider
+          .hass=${hass}
+          .config=${config}
+          .weatherEntity=${entity}
+        ></wfc-animation-provider>`
+      );
+      await provider.updateComplete;
+
+      const before = cloudFingerprints(provider);
+      expect(before.length).toBeGreaterThan(0);
+
+      // A hass refresh hands the provider a new entity object (e.g. temperature
+      // ticked) while the condition stays cloudy: clouds must not jump.
+      provider.weatherEntity = {
+        ...entity,
+        attributes: { ...entity.attributes, temperature: 9 },
+      } as WeatherEntity;
+      await provider.updateComplete;
+
+      expect(cloudFingerprints(provider)).toEqual(before);
+    });
+  });
+
+  describe("cloud drift direction", () => {
+    const driftsRight = async (windBearing: number): Promise<boolean> => {
+      const mockHass = new MockHass({ currentCondition: "cloudy" });
+      const hass = mockHass.getHass() as ExtendedHomeAssistant;
+      const entity = hass.states["weather.demo"] as WeatherEntity;
+      const config: WeatherForecastCardConfig = {
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+        show_condition_effects: true,
+        forecast: { show_sun_times: false },
+      };
+      const forecast = {
+        datetime: "2026-01-01T00:00:00Z",
+        wind_bearing: windBearing,
+        wind_speed: 10,
+      } as ForecastAttribute;
+
+      const provider = await fixture<WeatherAnimationProvider>(
+        html`<wfc-animation-provider
+          .hass=${hass}
+          .config=${config}
+          .weatherEntity=${entity}
+          .currentForecast=${forecast}
+        ></wfc-animation-provider>`
+      );
+      await provider.updateComplete;
+
+      return (
+        provider.shadowRoot
+          ?.querySelector(".cloud-track")
+          ?.classList.contains("drift-right") ?? false
+      );
+    };
+
+    it("drifts right when the wind blows toward the east (from the west)", async () => {
+      expect(await driftsRight(270)).toBe(true);
+    });
+
+    it("drifts left when the wind blows toward the west (from the east)", async () => {
+      expect(await driftsRight(90)).toBe(false);
+    });
+  });
 });
+
+const cloudFingerprints = (provider: WeatherAnimationProvider): string[] =>
+  Array.from(provider.shadowRoot?.querySelectorAll(".cloud") ?? []).map(
+    // Normalize whitespace: the serialized style string spacing can differ
+    // between renders even when the values (positions/sizes) are identical.
+    (el) =>
+      `${el.className}|${(el.getAttribute("style") ?? "").replace(/\s+/g, "")}`
+  );
 
 const createFixture = async (
   condition: string,


### PR DESCRIPTION
Closes #136.

Adds a `cloud` condition effect for the `cloudy` and `partlycloudy` weather states.

- **Realistic clouds:** soft cumulus silhouettes roughened by an SVG turbulence filter, with volumetric shading — not flat rounded shapes.
- **Per condition:** `cloudy` renders a soft overcast grey sky with a translucent grey deck (no sun/moon); `partlycloudy` keeps the blue/night sky and sun or moon with a few lighter clouds.
- **Depth & parallax:** clouds are split across near/far layers — smaller, fainter background clouds drift slower, larger foreground clouds faster.
- **Wind-driven drift:** direction follows the wind bearing, speed scales with wind speed.
- **Readability:** clouds sit toward the top, stay translucent, and are dimmed at night so card text stays legible.
- Theme-aware (light/dark) with new CSS custom properties; togglable in the card editor like the other effects.

Cloud particles are cached and only regenerated when coverage or day/night changes, so they don't jump on hass refreshes.

Tests cover condition mapping, effect gating, particle stability across refreshes, and drift direction.