### PR TITLE
feat: legibility shadow for current weather text over clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ Customize the appearance of animated weather effects when `show_condition_effect
 | `weather-forecast-card-effects-overcast-night-accent`  | Light: `rgba(55, 62, 76, 0.65)` / Dark: `rgba(30, 36, 47, 0.7)`    | Night overcast sky gradient accent color               |
 | `weather-forecast-card-effects-overcast-night-horizon` | Light: `rgba(78, 86, 100, 0.45)` / Dark: `rgba(48, 55, 68, 0.5)`   | Night overcast sky gradient horizon color              |
 | `weather-forecast-card-effects-cloud-color`            | Light: `#f4f7fb` / Dark: `#dfe6ee`                                 | Base color of the drifting clouds                      |
+| `weather-forecast-card-effects-text-shadow`            | `0 1px 2px rgba(0, 0, 0, 0.5), 0 0 4px rgba(0, 0, 0, 0.35)`        | Legibility shadow on the current state and temperature so they stay readable over the drifting clouds (`cloudy` / `partlycloudy`). Set to `none` to disable |
+| `weather-forecast-card-effects-text-shadow-secondary`  | `0 1px 2px rgba(0, 0, 0, 0.55)`                                    | Legibility shadow on the smaller secondary text (entity name and secondary info). A tighter shadow than the primary one to keep small text crisp. Set to `none` to disable |
 
 > [!NOTE]
 > Weather effects variables support both light and dark themes. Colors automatically adjust based on your theme's dark mode setting, with separate default values optimized for each mode.

--- a/src/components/animation/wfc-animation-provider.ts
+++ b/src/components/animation/wfc-animation-provider.ts
@@ -165,6 +165,14 @@ export class WeatherAnimationProvider extends LitElement {
     if (changedProps.has("hass")) {
       this.onThemeChanged();
     }
+
+    // Reflect whether the cloud deck is active so the card can lift the current
+    // weather text off the clouds only when they are actually present (not for
+    // clear/sunny effects).
+    this.toggleAttribute(
+      "has-clouds",
+      this.getActiveEffects().includes("cloud")
+    );
   }
 
   protected render() {

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -113,6 +113,15 @@
     64px
   );
   --indicator-width: 20px;
+  --wfc-effects-text-shadow: var(
+    --weather-forecast-card-effects-text-shadow,
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 0 4px rgba(0, 0, 0, 0.35)
+  );
+  --wfc-effects-text-shadow-secondary: var(
+    --weather-forecast-card-effects-text-shadow-secondary,
+    0 1px 2px rgba(0, 0, 0, 0.55)
+  );
 }
 
 /* Modern browsers with color-mix support */
@@ -236,6 +245,20 @@ ha-card {
   font-size: var(--ha-font-size-3xl);
   line-height: var(--ha-line-height-condensed);
   white-space: nowrap;
+}
+
+wfc-animation-provider[has-clouds] ~ .wfc-container .wfc-current-state,
+wfc-animation-provider[has-clouds] ~ .wfc-container .wfc-current-temperature {
+  text-shadow: var(--wfc-effects-text-shadow);
+}
+
+wfc-animation-provider[has-clouds] ~ .wfc-container .wfc-name,
+wfc-animation-provider[has-clouds] ~ .wfc-container .wfc-current-secondary-value {
+  text-shadow: var(--wfc-effects-text-shadow-secondary);
+}
+
+wfc-animation-provider[has-clouds] ~ .wfc-container .wfc-current-secondary-icon {
+  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.5));
 }
 
 .wfc-current-attributes {


### PR DESCRIPTION
White current-weather text washed out over the drifting cloud deck (`cloudy` / `partlycloudy`). This adds a legibility text-shadow to that text.

- Gated on the cloud effect being active, so clear/sunny and other effects are unaffected. The animation provider reflects a `has-clouds` attribute; the card scopes the shadow to it.
- State and temperature get a scrim shadow; name and secondary info get a tighter shadow to stay crisp at their smaller size; the secondary icon gets a matching drop-shadow.
- Themeable via `--weather-forecast-card-effects-text-shadow` and `--weather-forecast-card-effects-text-shadow-secondary` (set `none` to disable).