### PR TITLE
fix: correct moon glow rendering on Safari

### DIFF
--- a/src/components/animation/wfc-animation-provider.ts
+++ b/src/components/animation/wfc-animation-provider.ts
@@ -820,15 +820,21 @@ export class WeatherAnimationProvider extends LitElement {
       ? moonLitPath(phase.fraction, phase.litRight)
       : moonLitPath(1, true);
 
+    // The blur lives on the padded wrapper div, not the svg (see the CSS). The svg
+    // keeps the original 0 0 100 100 viewBox and carries explicit width/height so
+    // Safari sizes it from the disc, not from an svg's 300x150 intrinsic default.
     return html`
-      <svg
-        class="moon-glow"
-        viewBox="0 0 100 100"
-        preserveAspectRatio="none"
-        aria-hidden="true"
-      >
-        <path d=${litPath}></path>
-      </svg>
+      <div class="moon-glow">
+        <svg
+          viewBox="0 0 100 100"
+          width="100"
+          height="100"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <path d=${litPath}></path>
+        </svg>
+      </div>
     `;
   }
 

--- a/src/components/animation/wfc-animation.css
+++ b/src/components/animation/wfc-animation.css
@@ -414,14 +414,29 @@
   height: var(--moon-size);
 }
 
-/* Blurred copy of the lit region behind the disc, so only the sunlit limb glows. */
+/* Blurred copy of the lit region behind the disc, so only the sunlit limb glows.
+   The wrapper is padded a quarter-disc past the moon on every side so the blur fades
+   to zero inside its box: WebKit clips a composited filter:blur() to its layer bounds,
+   which otherwise slices the glow into a hard rectangle. translateZ(0) pins it to a
+   stable GPU layer so that clip stays consistent during interaction. The inner svg is
+   given an EXPLICIT width/height: Safari won't stretch a replaced element to `inset`
+   and falls back to its intrinsic default, which blows the glow up into a stray blob. */
 .moon-glow {
   position: absolute;
-  inset: 0;
+  inset: calc(var(--moon-size) * -0.25);
   z-index: 0;
   overflow: visible;
   filter: blur(calc(var(--moon-size) * 0.06));
+  transform: translateZ(0);
   pointer-events: none;
+}
+
+.moon-glow svg {
+  position: absolute;
+  top: calc(var(--moon-size) * 0.25);
+  left: calc(var(--moon-size) * 0.25);
+  width: var(--moon-size);
+  height: var(--moon-size);
 }
 
 .moon-glow path {


### PR DESCRIPTION
## Problem

The moon glow rendered incorrectly on Safari (iOS and macOS) while looking fine on Chrome. Across reports it showed up as a hard rectangular box around the moon, a small glow shoved to the top-left, and a large diffuse blob dumped below the moon. Chrome was never affected.

## Root causes

Three distinct WebKit issues, each fixed:

1. **Composited `filter: blur()` clipped to the element box** → hard rectangle. Fixed by moving the blur onto a wrapper `<div>` padded a quarter-disc past the moon on every side, so the blurred halo stays inside the box and the compositing clip lands in transparent pixels.
2. **Non-zero SVG `viewBox` origin under a CSS filter is mis-mapped by Safari** (shrunk/offset glow). Fixed by keeping the inner svg at the original `viewBox="0 0 100 100"`.
3. **Safari does not stretch a replaced element (svg) to `inset`** and falls back to the 300×150 intrinsic default (oversized/offset blob). Fixed by giving the inner svg explicit `width`/`height` (attributes + CSS `var(--moon-size)`) and explicit `top`/`left`.

`transform: translateZ(0)` is applied to the wrapper for a stable GPU layer during interaction; it is safe once the svg is explicitly sized.

## Verification

Validated against the system WebKit engine via `qlmanage` (Quick Look, same engine as Safari) using a standalone repro that reproduced the bug; the fix renders a clean contained halo. Confirmed unchanged on Chrome. Lint clean, 399 tests pass, build succeeds. Fix confirmed on-device by the reporter.