### PR TITLE
fix: resolve entity-only sensor icons via ha-state-icon

### DIFF
--- a/src/components/wfc-current-weather-attributes.ts
+++ b/src/components/wfc-current-weather-attributes.ts
@@ -94,17 +94,34 @@ export class WfcCurrentWeatherAttributes extends LitElement {
     const customEntity = customEntityId
       ? this.hass.states[customEntityId]
       : undefined;
-    const icon = resolveAttributeIcon(attribute, explicitIcon, customEntity);
+
+    // A pure custom-entity item (an entity with no weather-attribute name) lets HA's
+    // ha-state-icon resolve the icon, so it honors the entity's own icon from any source
+    // (state attribute, registry, icons.json translations, device_class default). An
+    // attribute-backed item keeps the weather-attribute icon so it matches its label.
+    const iconTemplate =
+      customEntity && !attribute
+        ? html`
+            <ha-state-icon
+              class="wfc-current-attribute-icon"
+              .hass=${this.hass}
+              .stateObj=${customEntity}
+              .icon=${explicitIcon}
+            ></ha-state-icon>
+          `
+        : html`
+            <ha-attribute-icon
+              class="wfc-current-attribute-icon"
+              .hass=${this.hass}
+              .stateObj=${stateObj}
+              .attribute=${attribute}
+              .icon=${resolveAttributeIcon(attribute, explicitIcon, customEntity)}
+            ></ha-attribute-icon>
+          `;
 
     return html`
       <div class="wfc-current-attribute">
-        <ha-attribute-icon
-          class="wfc-current-attribute-icon"
-          .hass=${this.hass}
-          .stateObj=${stateObj}
-          .attribute=${attribute}
-          .icon=${icon}
-        ></ha-attribute-icon>
+        ${iconTemplate}
         <span class="wfc-current-attribute-name">
           ${this.resolveLabel(attribute, explicitLabel, customEntity)}
         </span>

--- a/src/components/wfc-current-weather.ts
+++ b/src/components/wfc-current-weather.ts
@@ -8,7 +8,7 @@ import {
   handleAction,
   hasAction,
 } from "custom-card-helpers";
-import { HassEntity } from "home-assistant-js-websocket";
+import type { HassEntity } from "home-assistant-js-websocket";
 import {
   CURRENT_WEATHER_ATTRIBUTES,
   CurrentWeatherAttributes,

--- a/src/components/wfc-current-weather.ts
+++ b/src/components/wfc-current-weather.ts
@@ -8,6 +8,7 @@ import {
   handleAction,
   hasAction,
 } from "custom-card-helpers";
+import { HassEntity } from "home-assistant-js-websocket";
 import {
   CURRENT_WEATHER_ATTRIBUTES,
   CurrentWeatherAttributes,
@@ -36,6 +37,7 @@ export type NormalizedAttributeConfig = {
 
 type SecondaryInfo = {
   icon?: string;
+  stateObj?: HassEntity;
   value?: string;
 };
 
@@ -120,15 +122,24 @@ export class WfcCurrentWeather extends LitElement {
             ${secondaryInfo
               ? html`
                   <div class="wfc-current-secondary-info">
-                    ${secondaryInfo.icon
+                    ${secondaryInfo.stateObj
                       ? html`
-                          <ha-attribute-icon
+                          <ha-state-icon
                             class="wfc-current-secondary-icon wfc-secondary"
                             .hass=${this.hass}
+                            .stateObj=${secondaryInfo.stateObj}
                             .icon=${secondaryInfo.icon}
-                          ></ha-attribute-icon>
+                          ></ha-state-icon>
                         `
-                      : nothing}
+                      : secondaryInfo.icon
+                        ? html`
+                            <ha-attribute-icon
+                              class="wfc-current-secondary-icon wfc-secondary"
+                              .hass=${this.hass}
+                              .icon=${secondaryInfo.icon}
+                            ></ha-attribute-icon>
+                          `
+                        : nothing}
                     <span class="wfc-current-secondary-value wfc-secondary"
                       >${secondaryInfo.value}</span
                     >
@@ -266,14 +277,18 @@ export class WfcCurrentWeather extends LitElement {
 
         if (value != null) {
           const customEntity = this.hass.states[customEntityId];
+
+          if (!name) {
+            // Entity-only: let ha-state-icon resolve the entity's own icon.
+            return { stateObj: customEntity, icon: explicitIcon, value };
+          }
+
           const icon =
             explicitIcon ??
             customEntity?.attributes?.icon ??
-            (name
-              ? (EXTENDED_WEATHER_ATTRIBUTE_ICON_MAP as Record<string, string>)[
-                  name
-                ]
-              : undefined);
+            (EXTENDED_WEATHER_ATTRIBUTE_ICON_MAP as Record<string, string>)[
+              name
+            ];
 
           return { icon, value };
         }

--- a/test/current-weather-attributes.test.ts
+++ b/test/current-weather-attributes.test.ts
@@ -403,6 +403,46 @@ describe("secondary_info_attribute", () => {
     expect(value?.textContent?.trim()).toBe("1013 hPa");
   });
 
+  it("renders secondary info from an entity-only custom sensor via ha-state-icon", async () => {
+    const mockHass = new MockHass();
+    const testHass = mockHass.getHass() as ExtendedHomeAssistant;
+    testHass.states["weather.demo"] = weatherEntity;
+
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${testHass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            secondary_info_attribute: {
+              entity: "sensor.custom_pressure",
+            } as CurrentWeatherAttributeConfig,
+          },
+        }}
+        .hourlyForecast=${mockHass.hourlyForecast}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const secondaryInfo = el.querySelector(".wfc-current-secondary-info");
+    expect(secondaryInfo).not.toBeNull();
+
+    // Icon resolution is delegated to HA, not force-fed as mdi:gauge.
+    expect(secondaryInfo?.querySelector("ha-attribute-icon")).toBeNull();
+
+    const stateIcon = secondaryInfo?.querySelector("ha-state-icon");
+    expect(stateIcon).not.toBeNull();
+    // @ts-expect-error mock property
+    expect(stateIcon?.stateObj?.entity_id).toBe("sensor.custom_pressure");
+    // @ts-expect-error mock property
+    expect(stateIcon?.icon).toBeUndefined();
+
+    const value = secondaryInfo?.querySelector(".wfc-current-secondary-value");
+    expect(value?.textContent?.trim()).toBe("1025 hPa");
+  });
+
   it("falls back to extrema when secondary_info_attribute is non-existent", async () => {
     const mockHass = new MockHass();
     mockHass.hourlyForecast = [
@@ -809,6 +849,91 @@ describe("custom entity attributes", () => {
     // explicit label override works on an entity-only item
     expect(labels[1]).toBe("Outside");
     expect(values[1]).toBe("1025 hPa");
+  });
+
+  it("delegates entity-only icons to ha-state-icon instead of forcing mdi:gauge", async () => {
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: [
+              { entity: "sensor.custom_pressure" },
+            ] as CurrentWeatherAttributeConfig[],
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes")!;
+
+    // The entity's own icon is resolved by HA, not force-fed as mdi:gauge.
+    expect(attrEl.querySelector("ha-attribute-icon")).toBeNull();
+
+    const stateIcon = attrEl.querySelector("ha-state-icon");
+    expect(stateIcon).not.toBeNull();
+    // @ts-expect-error mock property
+    expect(stateIcon?.stateObj?.entity_id).toBe("sensor.custom_pressure");
+    // No explicit icon -> delegated to ha-state-icon (undefined prop).
+    // @ts-expect-error mock property
+    expect(stateIcon?.icon).toBeUndefined();
+  });
+
+  it("passes an explicit icon through to ha-state-icon for entity-only items", async () => {
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: [
+              { entity: "sensor.custom_pressure", icon: "mdi:abacus" },
+            ] as CurrentWeatherAttributeConfig[],
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes")!;
+    const stateIcon = attrEl.querySelector("ha-state-icon");
+    expect(stateIcon).not.toBeNull();
+    // @ts-expect-error mock property
+    expect(stateIcon?.icon).toBe("mdi:abacus");
+  });
+
+  it("keeps the weather-attribute icon for an attribute backed by a custom entity", async () => {
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: [
+              { name: "humidity", entity: "sensor.custom_humidity" },
+            ] as CurrentWeatherAttributeConfig[],
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes")!;
+    // A named attribute keeps the attribute icon so it matches its label.
+    expect(attrEl.querySelector("ha-state-icon")).toBeNull();
+
+    const attrIcon = attrEl.querySelector("ha-attribute-icon");
+    expect(attrIcon).not.toBeNull();
+    // @ts-expect-error mock property
+    expect(attrIcon?.icon).toBe("mdi:water-percent");
   });
 
   it("skips attribute when custom entity is unavailable", async () => {

--- a/test/mocks/ha-state-icon.ts
+++ b/test/mocks/ha-state-icon.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, TemplateResult, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { HassEntity } from "home-assistant-js-websocket";
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { ExtendedHomeAssistant } from "../../src/types";
 
 /**

--- a/test/mocks/ha-state-icon.ts
+++ b/test/mocks/ha-state-icon.ts
@@ -1,0 +1,42 @@
+import { LitElement, html, TemplateResult, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { HassEntity } from "home-assistant-js-websocket";
+import type { ExtendedHomeAssistant } from "../../src/types";
+
+/**
+ * Mock component for ha-state-icon
+ *
+ * The real element resolves an entity's icon from every HA source (state attribute,
+ * entity registry, icons.json translations, device_class default, domain default),
+ * which a unit test cannot replicate. This mock reflects only what is observable on
+ * the state object: an explicit .icon prop, then state attributes.icon. Tests assert
+ * on the .stateObj / .icon properties rather than the rendered glyph.
+ */
+@customElement("ha-state-icon")
+export class HaStateIcon extends LitElement {
+  // @ts-expect-error test component
+  @property({ attribute: false }) hass!: ExtendedHomeAssistant;
+  // @ts-expect-error test component
+  @property({ attribute: false }) stateObj?: HassEntity;
+  // @ts-expect-error test component
+  @property({ attribute: false }) icon?: string;
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    const resolved = this.icon ?? this.stateObj?.attributes?.icon;
+    if (!resolved) {
+      return nothing;
+    }
+
+    return html`<span class="mock-state-icon" data-icon=${resolved}></span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-state-icon": HaStateIcon;
+  }
+}

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,4 +1,5 @@
 export * from "./ha-attribute-icon";
+export * from "./ha-state-icon";
 export * from "./ha-icon";
 export * from "./hass";
 export * from "./test-data";


### PR DESCRIPTION
Entity-only custom sensors (`{ entity: sensor.x }`, no name/icon) showed `mdi:gauge` instead of the entity's own icon.

Cause: the card only read `state.attributes.icon`, which is empty when an integration provides the icon via `icons.json` (device_class/translation_key) — the frontend resolves those and never puts them on the state object.

Fix: delegate to HA `<ha-state-icon>` for entity-only items in the attributes grid and `secondary_info`, so HA runs its full resolution chain. Named weather attributes keep `<ha-attribute-icon>`; an explicit config `icon` still wins.