### PR TITLE
fix: react to current-section sensor changes

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -292,10 +292,14 @@ export const endOfHour = (input: Date | string): Date => {
   return d;
 };
 
-const entityOf = (item: unknown): string | undefined =>
-  item != null && typeof item === "object"
-    ? (item as CurrentWeatherAttributeConfig).entity
-    : undefined;
+const entityOf = (item: unknown): string | undefined => {
+  const entity =
+    item != null && typeof item === "object"
+      ? (item as CurrentWeatherAttributeConfig).entity
+      : undefined;
+
+  return typeof entity === "string" ? entity : undefined;
+};
 
 /**
  * Collects the entity ids the current-weather section reads from `hass.states`
@@ -337,6 +341,10 @@ export const getReferencedCurrentEntities = (
       ids.add(entity);
     }
   }
+
+  // The primary entity is tracked separately by hasConfigOrEntityChanged; drop it
+  // if a current-section entity happens to point at the same id.
+  ids.delete(config.entity);
 
   return [...ids];
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,11 @@ import { HomeAssistant, TimeFormat } from "custom-card-helpers";
 import { STATE_NOT_RUNNING } from "home-assistant-js-websocket";
 import * as SunCalc from "suncalc";
 import memoizeOne from "memoize-one";
-import { SuntimesInfo } from "./types";
+import {
+  CurrentWeatherAttributeConfig,
+  SuntimesInfo,
+  WeatherForecastCardConfig,
+} from "./types";
 
 export interface HourParts {
   hour: string;
@@ -286,4 +290,53 @@ export const endOfHour = (input: Date | string): Date => {
   d.setMinutes(59, 59, 999);
 
   return d;
+};
+
+const entityOf = (item: unknown): string | undefined =>
+  item != null && typeof item === "object"
+    ? (item as CurrentWeatherAttributeConfig).entity
+    : undefined;
+
+/**
+ * Collects the entity ids the current-weather section reads from `hass.states`
+ * beyond the primary weather entity: the temperature sensor, the secondary info
+ * entity and any custom entities used in `show_attributes`. Used to keep the
+ * card reactive to those sensors (see `shouldUpdate`); the primary `entity` is
+ * intentionally excluded because `hasConfigOrEntityChanged` already tracks it.
+ */
+export const getReferencedCurrentEntities = (
+  config: WeatherForecastCardConfig
+): string[] => {
+  const current = config.current;
+  if (!current) {
+    return [];
+  }
+
+  const ids = new Set<string>();
+
+  if (current.temperature_entity) {
+    ids.add(current.temperature_entity);
+  }
+
+  const secondaryEntity = entityOf(current.secondary_info_attribute);
+  if (secondaryEntity) {
+    ids.add(secondaryEntity);
+  }
+
+  const showAttr = current.show_attributes;
+  if (Array.isArray(showAttr)) {
+    for (const item of showAttr) {
+      const entity = entityOf(item);
+      if (entity) {
+        ids.add(entity);
+      }
+    }
+  } else {
+    const entity = entityOf(showAttr);
+    if (entity) {
+      ids.add(entity);
+    }
+  }
+
+  return [...ids];
 };

--- a/src/weather-forecast-card.ts
+++ b/src/weather-forecast-card.ts
@@ -1,7 +1,11 @@
 import { merge } from "lodash-es";
 import { property, query, state } from "lit/decorators.js";
 import { styles } from "./weather-forecast-card.styles";
-import { createWarningText, normalizeDate } from "./helpers";
+import {
+  createWarningText,
+  getReferencedCurrentEntities,
+  normalizeDate,
+} from "./helpers";
 import { logger } from "./logger";
 import {
   actionHandler,
@@ -295,6 +299,7 @@ export class WeatherForecastCard extends LitElement {
   protected shouldUpdate(changedProperties: PropertyValues): boolean {
     return (
       hasConfigOrEntityChanged(this, changedProperties, false) ||
+      this.hasReferencedCurrentEntityChanged(changedProperties) ||
       changedProperties.has("_dailyForecastEvent") ||
       changedProperties.has("_hourlyForecastEvent") ||
       changedProperties.has("_currentForecastType") ||
@@ -1015,6 +1020,30 @@ export class WeatherForecastCard extends LitElement {
     const newEntityState = newHass.states[this.config.entity];
 
     return !!oldEntityState !== !!newEntityState;
+  }
+
+  private hasReferencedCurrentEntityChanged(
+    changedProps: PropertyValues
+  ): boolean {
+    if (!changedProps.has("hass") || !this.config) {
+      return false;
+    }
+
+    const oldHass = changedProps.get("hass") as
+      | ExtendedHomeAssistant
+      | undefined;
+    const newHass = this.hass;
+
+    if (!oldHass || !newHass) {
+      return false;
+    }
+
+    // hasConfigOrEntityChanged only tracks the primary weather entity, but the
+    // current section can also read custom sensors (temperature_entity,
+    // secondary info, show_attributes). React when any of those change too.
+    return getReferencedCurrentEntities(this.config).some(
+      (entityId) => oldHass.states[entityId] !== newHass.states[entityId]
+    );
   }
 
   private onForecastAction = (event: ForecastActionEvent): void => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { getReferencedCurrentEntities } from "../src/helpers";
+import { WeatherForecastCardConfig } from "../src/types";
+
+const baseConfig = (
+  current: WeatherForecastCardConfig["current"]
+): WeatherForecastCardConfig => ({
+  type: "custom:weather-forecast-card",
+  entity: "weather.demo",
+  current,
+});
+
+describe("getReferencedCurrentEntities", () => {
+  it("returns nothing when there is no current section", () => {
+    expect(
+      getReferencedCurrentEntities({
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+      })
+    ).toEqual([]);
+  });
+
+  it("never includes the primary weather entity", () => {
+    expect(getReferencedCurrentEntities(baseConfig({}))).toEqual([]);
+  });
+
+  it("collects the temperature_entity", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({ temperature_entity: "sensor.outdoor_temp" })
+      )
+    ).toEqual(["sensor.outdoor_temp"]);
+  });
+
+  it("collects the secondary_info_attribute custom entity", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({
+          secondary_info_attribute: {
+            name: "humidity",
+            entity: "sensor.custom_humidity",
+          },
+        })
+      )
+    ).toEqual(["sensor.custom_humidity"]);
+  });
+
+  it("ignores a string secondary_info_attribute (weather attribute, no entity)", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({ secondary_info_attribute: "humidity" })
+      )
+    ).toEqual([]);
+  });
+
+  it("collects custom entities from an array of show_attributes", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({
+          show_attributes: [
+            "humidity",
+            { name: "pressure", entity: "sensor.custom_pressure" },
+            { entity: "sensor.custom_wind_speed" },
+            null as never,
+          ],
+        })
+      )
+    ).toEqual(["sensor.custom_pressure", "sensor.custom_wind_speed"]);
+  });
+
+  it("collects a custom entity from a single-object show_attributes", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({ show_attributes: { entity: "sensor.custom_dew_point" } })
+      )
+    ).toEqual(["sensor.custom_dew_point"]);
+  });
+
+  it("ignores boolean and string forms of show_attributes", () => {
+    expect(
+      getReferencedCurrentEntities(baseConfig({ show_attributes: true }))
+    ).toEqual([]);
+    expect(
+      getReferencedCurrentEntities(baseConfig({ show_attributes: "humidity" }))
+    ).toEqual([]);
+  });
+
+  it("de-duplicates entities referenced from multiple sources", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({
+          temperature_entity: "sensor.outdoor_temp",
+          secondary_info_attribute: { entity: "sensor.outdoor_temp" },
+          show_attributes: [{ entity: "sensor.outdoor_temp" }],
+        })
+      )
+    ).toEqual(["sensor.outdoor_temp"]);
+  });
+});

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -85,6 +85,30 @@ describe("getReferencedCurrentEntities", () => {
     ).toEqual([]);
   });
 
+  it("excludes a current-section entity that equals the primary entity", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({
+          temperature_entity: "weather.demo",
+          show_attributes: [{ entity: "weather.demo" }],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("ignores non-string entity values from misconfigured yaml", () => {
+    expect(
+      getReferencedCurrentEntities(
+        baseConfig({
+          show_attributes: [{ entity: 123 as unknown as string }],
+          secondary_info_attribute: {
+            entity: 456 as unknown as string,
+          },
+        })
+      )
+    ).toEqual([]);
+  });
+
   it("de-duplicates entities referenced from multiple sources", () => {
     expect(
       getReferencedCurrentEntities(

--- a/test/weather-forecast-card.test.ts
+++ b/test/weather-forecast-card.test.ts
@@ -1093,6 +1093,204 @@ describe("weather-forecast-card", () => {
     });
   });
 
+  describe("current entity reactivity", () => {
+    const reactiveConfig: WeatherForecastCardConfig = {
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      current: {
+        temperature_entity: "sensor.temperature_outdoor",
+      },
+      forecast: {
+        show_sun_times: false,
+      },
+    };
+
+    const currentTemperatureText = (el: WeatherForecastCard): string =>
+      el.shadowRoot!.querySelector(".wfc-current-temperature")
+        ?.textContent?.trim() ?? "";
+
+    // Same weather.demo reference, only the temperature sensor state object changes.
+    // This is exactly the case hasConfigOrEntityChanged misses (issue #160).
+    const withChangedTemperature = (
+      base: ExtendedHomeAssistant,
+      state: string
+    ): ExtendedHomeAssistant =>
+      ({
+        ...base,
+        states: {
+          ...base.states,
+          "sensor.temperature_outdoor": {
+            ...base.states["sensor.temperature_outdoor"],
+            state,
+          },
+        },
+      }) as ExtendedHomeAssistant;
+
+    it("re-renders when temperature_entity changes without a weather entity change", async () => {
+      const baseHass = mockHassInstance.getHass() as ExtendedHomeAssistant;
+
+      const testCard = await fixture<WeatherForecastCard>(
+        html`<weather-forecast-card
+          .hass=${baseHass}
+          .config=${reactiveConfig}
+        ></weather-forecast-card>`
+      );
+
+      testCard.setConfig(reactiveConfig);
+      await testCard.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(currentTemperatureText(testCard)).toBe(
+        `${baseHass.states["sensor.temperature_outdoor"].state}°C`
+      );
+
+      const changedHass = withChangedTemperature(baseHass, "42");
+      // The primary weather entity is untouched, so only the new watching logic
+      // can trigger the update.
+      expect(changedHass.states["weather.demo"]).toBe(
+        baseHass.states["weather.demo"]
+      );
+
+      testCard.hass = changedHass;
+      await testCard.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(currentTemperatureText(testCard)).toBe("42°C");
+    });
+
+    it("shouldUpdate returns true when a referenced current entity changes", async () => {
+      const baseHass = mockHassInstance.getHass() as ExtendedHomeAssistant;
+
+      const testCard = await fixture<WeatherForecastCard>(
+        html`<weather-forecast-card
+          .hass=${baseHass}
+          .config=${reactiveConfig}
+        ></weather-forecast-card>`
+      );
+
+      testCard.setConfig(reactiveConfig);
+      await testCard.updateComplete;
+
+      testCard.hass = withChangedTemperature(baseHass, "42");
+
+      // @ts-expect-error: accessing protected method
+      expect(testCard.shouldUpdate(new Map([["hass", baseHass]]))).toBe(true);
+    });
+
+    it("shouldUpdate returns true when a show_attributes custom entity changes", async () => {
+      const baseHass = mockHassInstance.getHass() as ExtendedHomeAssistant;
+
+      const config: WeatherForecastCardConfig = {
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+        current: {
+          show_attributes: [
+            "humidity",
+            { name: "pressure", entity: "sensor.custom_pressure" },
+          ],
+        },
+        forecast: { show_sun_times: false },
+      };
+
+      const testCard = await fixture<WeatherForecastCard>(
+        html`<weather-forecast-card
+          .hass=${baseHass}
+          .config=${config}
+        ></weather-forecast-card>`
+      );
+
+      testCard.setConfig(config);
+      await testCard.updateComplete;
+
+      // Only the custom attribute sensor changes; weather.demo is untouched.
+      testCard.hass = {
+        ...baseHass,
+        states: {
+          ...baseHass.states,
+          "sensor.custom_pressure": {
+            ...baseHass.states["sensor.custom_pressure"],
+            state: "999",
+          },
+        },
+      } as ExtendedHomeAssistant;
+
+      // @ts-expect-error: accessing protected method
+      expect(testCard.shouldUpdate(new Map([["hass", baseHass]]))).toBe(true);
+    });
+
+    it("shouldUpdate returns true when a secondary_info_attribute custom entity changes", async () => {
+      const baseHass = mockHassInstance.getHass() as ExtendedHomeAssistant;
+
+      const config: WeatherForecastCardConfig = {
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+        current: {
+          secondary_info_attribute: {
+            name: "humidity",
+            entity: "sensor.custom_humidity",
+          },
+        },
+        forecast: { show_sun_times: false },
+      };
+
+      const testCard = await fixture<WeatherForecastCard>(
+        html`<weather-forecast-card
+          .hass=${baseHass}
+          .config=${config}
+        ></weather-forecast-card>`
+      );
+
+      testCard.setConfig(config);
+      await testCard.updateComplete;
+
+      testCard.hass = {
+        ...baseHass,
+        states: {
+          ...baseHass.states,
+          "sensor.custom_humidity": {
+            ...baseHass.states["sensor.custom_humidity"],
+            state: "1",
+          },
+        },
+      } as ExtendedHomeAssistant;
+
+      // @ts-expect-error: accessing protected method
+      expect(testCard.shouldUpdate(new Map([["hass", baseHass]]))).toBe(true);
+    });
+
+    it("shouldUpdate returns false when only an unwatched entity changes", async () => {
+      const baseHass = mockHassInstance.getHass() as ExtendedHomeAssistant;
+
+      const testCard = await fixture<WeatherForecastCard>(
+        html`<weather-forecast-card
+          .hass=${baseHass}
+          .config=${reactiveConfig}
+        ></weather-forecast-card>`
+      );
+
+      testCard.setConfig(reactiveConfig);
+      await testCard.updateComplete;
+
+      // Change an entity the card does not reference; weather + temperature sensor
+      // references are preserved.
+      const unrelatedHass = {
+        ...baseHass,
+        states: {
+          ...baseHass.states,
+          "sensor.custom_humidity": {
+            ...baseHass.states["sensor.custom_humidity"],
+            state: "1",
+          },
+        },
+      } as ExtendedHomeAssistant;
+
+      testCard.hass = unrelatedHass;
+
+      // @ts-expect-error: accessing protected method
+      expect(testCard.shouldUpdate(new Map([["hass", baseHass]]))).toBe(false);
+    });
+  });
+
   describe("websocket reconnection", () => {
     it("should resubscribe after the websocket reconnects", async () => {
       const forecastHass = new MockHass();


### PR DESCRIPTION
Fixes #160.

## Problem

`temperature_entity` (and other current-section sensors) do not update in real time. The value only refreshes when the user interacts with the card or reloads the dashboard.

## Root cause

`shouldUpdate` gates re-renders on `hasConfigOrEntityChanged`, which only diffs the primary `config.entity` (the weather entity) between the old and new `hass`. The current section also reads other entities from `hass.states` that are never watched:

- `current.temperature_entity`
- `current.secondary_info_attribute.entity`
- `current.show_attributes[].entity`

When only one of those sensors changes, `shouldUpdate` returns `false`, Lit skips the update, and the child never receives the new `hass`. The value stays stale until an unrelated re-render (tap, scroll, reload, or the weather entity itself ticking) happens to occur.

## Fix

Add `getReferencedCurrentEntities(config)` to collect the current-section entities and a `hasReferencedCurrentEntityChanged` predicate that diffs their state objects across `hass` updates. It is OR'd into `shouldUpdate` alongside the existing `hasConfigOrEntityChanged`, so the primary-entity fast path is unchanged and the extra check only runs on `hass` changes.

This covers the whole class of current-section sensors, not just `temperature_entity`.

## Tests

- `getReferencedCurrentEntities`: temperature entity, secondary info entity, `show_attributes` (array/object/string/boolean), de-duplication, primary entity excluded.
- Card `shouldUpdate`: returns `true` when a `temperature_entity`, `show_attributes` custom entity, or `secondary_info_attribute` custom entity changes while the weather entity is unchanged; returns `false` when an unreferenced entity changes.
- Card render: current temperature updates when `temperature_entity` changes with no weather entity change.

`pnpm lint`, `pnpm test` (417 pass), and `pnpm build` all clean.