### PR TITLE
fix: use ha-button size="s" to avoid deprecation warning

### DIFF
--- a/src/components/wfc-forecast-chart.ts
+++ b/src/components/wfc-forecast-chart.ts
@@ -210,7 +210,7 @@ export class WfcForecastChart extends LitElement {
               <div class="wfc-forecast-chart-attribute-selector">
                 <ha-button
                   class="wfc-settings-toggle-button"
-                  size="small"
+                  size="s"
                   appearance="filled"
                   variant="brand"
                   @click=${this._onSettingsToggle}

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -616,7 +616,7 @@ export class WeatherForecastCardEditor
             this._renderCustomAttributeRow(item, index)
           )}
           <ha-button
-            size="small"
+            size="s"
             appearance="filled"
             variant="brand"
             @click=${this._addCustomAttribute}


### PR DESCRIPTION
Fixes #173

HA 2026.7 logs a deprecation warning for the long-form `ha-button` `size="small"`:

```
[ha-button] size="small" is deprecated. Use size="s" instead. The long-form value will be removed in the next major version.
```

Replace `size="small"` with the short-form `size="s"` at both call sites:

- `src/components/wfc-forecast-chart.ts` — chart attribute selector toggle button
- `src/editor/weather-forecast-card-editor.ts` — add custom attribute button

These were the only two long-form `size` values in the codebase. Renders identically; silences the warning and stays forward-compatible for when HA removes the long-form value. Lint, 424 tests, and build all pass.
