### PR TITLE
feat: add compact grid layout for current weather attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `current` object controls the display of current weather information and att
 | `show_attributes`          | `boolean`/`string`/`array` | optional | Display weather attributes below current conditions. Set to `true` to show all available attributes, `false` to hide all, a single attribute name (e.g., `"humidity"`), or an array of attribute names or objects. Objects can override the value `entity`, `label` and `icon`, or display an arbitrary entity. See [Custom Attributes](#custom-attributes) for advanced configuration.                                                 |
 | `secondary_info_attribute` | `string`/`object`          | optional | Controls which secondary info is displayed below current temperature. Supports all available weather attributes. Can also be an object `{ name?, entity?, icon? }` to source the value from a custom entity (see [Custom Attributes](#custom-attributes); note that `label` is not rendered for secondary info). If not set, or if the given attribute is not available in the weather entity, it will default to temperature extrema (high/low) if available, if not available then `precipitation` and if precipitation isn't available then `humidity`. |
 | `temperature_precision`    | `number`                   | optional | Number of decimal places to display for temperature values (0-2). Applies to current temperature, high/low temperatures, and temperature-related attributes like dew point and apparent temperature.                                                                                                                                                       |
+| `attributes_layout`        | `string`                   | `default` | Layout of the attributes list. `default` is a full-width vertical list (icon + label + value, one per line). `compact` is a fixed two-column grid of icon + value chips: labels are dropped (kept as a hover tooltip), and the right column is mirrored so icons sit against both card edges.                                                              |
 
 **Available attributes:**
 
@@ -181,6 +182,17 @@ current:
       icon: mdi:flower
     - entity: sensor.uv_today # label defaults to the entity's friendly name
     - humidity # Standard weather attribute alongside custom ones
+```
+
+```yaml
+# Compact two-column layout (icon + value chips, no labels)
+current:
+  attributes_layout: compact
+  show_attributes:
+    - humidity
+    - pressure
+    - wind_speed
+    - visibility
 ```
 
 > [!TIP]

--- a/src/components/wfc-current-weather-attributes.ts
+++ b/src/components/wfc-current-weather-attributes.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import { capitalize } from "lodash-es";
 import memoizeOne from "memoize-one";
 import {
@@ -36,8 +37,10 @@ export class WfcCurrentWeatherAttributes extends LitElement {
       return nothing;
     }
 
+    const compact = this.config?.current?.attributes_layout === "compact";
+
     const attributeTemplates = this.attributeConfigs
-      .map((attrConfig) => this._renderAttribute(attrConfig))
+      .map((attrConfig) => this._renderAttribute(attrConfig, compact))
       .filter((template) => template !== nothing);
 
     if (attributeTemplates.length === 0) {
@@ -45,12 +48,20 @@ export class WfcCurrentWeatherAttributes extends LitElement {
     }
 
     return html`
-      <div class="wfc-current-attributes">${attributeTemplates}</div>
+      <div
+        class=${classMap({
+          "wfc-current-attributes": true,
+          "wfc-compact": compact,
+        })}
+      >
+        ${attributeTemplates}
+      </div>
     `;
   }
 
   private _renderAttribute(
-    attrConfig: NormalizedAttributeConfig
+    attrConfig: NormalizedAttributeConfig,
+    compact: boolean
   ): TemplateResult | typeof nothing {
     if (!attrConfig || (!attrConfig.name && !attrConfig.entity)) {
       return nothing;
@@ -119,12 +130,14 @@ export class WfcCurrentWeatherAttributes extends LitElement {
             ></ha-attribute-icon>
           `;
 
+    const label = this.resolveLabel(attribute, explicitLabel, customEntity);
+
     return html`
-      <div class="wfc-current-attribute">
+      <div class="wfc-current-attribute" title=${compact ? label : nothing}>
         ${iconTemplate}
-        <span class="wfc-current-attribute-name">
-          ${this.resolveLabel(attribute, explicitLabel, customEntity)}
-        </span>
+        ${compact
+          ? nothing
+          : html`<span class="wfc-current-attribute-name">${label}</span>`}
         <span class="wfc-current-attribute-value">${value}</span>
       </div>
     `;

--- a/src/components/wfc-current-weather-attributes.ts
+++ b/src/components/wfc-current-weather-attributes.ts
@@ -133,7 +133,12 @@ export class WfcCurrentWeatherAttributes extends LitElement {
     const label = this.resolveLabel(attribute, explicitLabel, customEntity);
 
     return html`
-      <div class="wfc-current-attribute" title=${compact ? label : nothing}>
+      <div
+        class="wfc-current-attribute"
+        role=${compact ? "img" : nothing}
+        aria-label=${compact ? `${label}, ${value}` : nothing}
+        title=${compact ? label : nothing}
+      >
         ${iconTemplate}
         ${compact
           ? nothing

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -13,6 +13,7 @@ import {
 import {
   CHART_ATTRIBUTES,
   CURRENT_WEATHER_ATTRIBUTES,
+  CURRENT_WEATHER_ATTRIBUTES_LAYOUTS,
   CurrentWeatherAttributes,
   CurrentWeatherAttributeConfig,
   ExtendedHomeAssistant,
@@ -269,6 +270,19 @@ export class WeatherForecastCardEditor
               label:
                 localize(`ui.card.weather.attributes.${attribute}`) ||
                 capitalize(attribute).replace(/_/g, " "),
+            })),
+          },
+        },
+      },
+      {
+        name: "current.attributes_layout",
+        default: "default",
+        optional: true,
+        selector: {
+          select: {
+            options: CURRENT_WEATHER_ATTRIBUTES_LAYOUTS.map((layout) => ({
+              value: layout,
+              label: capitalize(layout),
             })),
           },
         },
@@ -948,6 +962,10 @@ export class WeatherForecastCardEditor
 
     if (newConfig?.forecast?.extra_attribute === "none") {
       delete newConfig.forecast.extra_attribute;
+    }
+
+    if (newConfig?.current?.attributes_layout === "default") {
+      delete newConfig.current.attributes_layout;
     }
 
     if (Array.isArray(newConfig.show_condition_effects)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,14 @@ export interface CurrentWeatherAttributeConfig {
   icon?: string;
 }
 
+export const CURRENT_WEATHER_ATTRIBUTES_LAYOUTS = [
+  "default",
+  "compact",
+] as const;
+
+export type CurrentWeatherAttributesLayout =
+  (typeof CURRENT_WEATHER_ATTRIBUTES_LAYOUTS)[number];
+
 export type WeatherEffect = (typeof WEATHER_EFFECTS)[number];
 
 export enum ForecastMode {
@@ -112,6 +120,7 @@ export interface WeatherForecastCardCurrentConfig {
   temperature_precision?: number;
   secondary_info_attribute?: CurrentWeatherAttributes | CurrentWeatherAttributeConfig;
   temperature_entity?: string;
+  attributes_layout?: CurrentWeatherAttributesLayout;
 }
 
 export interface WeatherForecastCardForecastActionConfig {

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -298,6 +298,41 @@ wfc-animation-provider.dark[has-clouds] ~ .wfc-container .wfc-current-secondary-
   flex: 1;
 }
 
+.wfc-current-attributes.wfc-compact {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: var(--ha-space-5, 20px);
+  row-gap: var(--ha-space-1, 4px);
+  align-items: center;
+}
+
+.wfc-current-attributes.wfc-compact .wfc-current-attribute {
+  justify-content: flex-start;
+  gap: var(--ha-space-2, 8px);
+  min-width: 0;
+}
+
+.wfc-current-attributes.wfc-compact .wfc-current-attribute-icon {
+  padding-left: 0;
+  flex: 0 0 auto;
+}
+
+.wfc-current-attributes.wfc-compact .wfc-current-attribute-value {
+  flex: 1;
+  min-width: 0;
+  text-overflow: ellipsis;
+}
+
+.wfc-current-attributes.wfc-compact .wfc-current-attribute:nth-child(even) {
+  flex-direction: row-reverse;
+}
+
+.wfc-current-attributes.wfc-compact
+  .wfc-current-attribute:nth-child(even)
+  .wfc-current-attribute-value {
+  text-align: right;
+}
+
 .wfc-forecast-container {
   pointer-events: auto;
 }

--- a/test/current-weather-attributes.test.ts
+++ b/test/current-weather-attributes.test.ts
@@ -215,6 +215,108 @@ describe("wfc-current-weather attributes", () => {
   });
 });
 
+describe("compact attributes layout", () => {
+  let hass: ExtendedHomeAssistant;
+  let weatherEntity: WeatherEntity;
+
+  beforeEach(() => {
+    const mockHass = new MockHass();
+    hass = mockHass.getHass() as ExtendedHomeAssistant;
+
+    const original = hass.states["weather.demo"] as WeatherEntity;
+    weatherEntity = {
+      ...original,
+      attributes: {
+        ...original.attributes,
+        humidity: 40,
+        pressure: 1000,
+        wind_speed: 5,
+        wind_bearing: undefined,
+      },
+    } as WeatherEntity;
+
+    hass.states["weather.demo"] = weatherEntity;
+  });
+
+  const renderAttributes = async (
+    layout?: "default" | "compact"
+  ): Promise<Element> => {
+    const el = await fixture<WfcCurrentWeather>(
+      html`<wfc-current-weather
+        .hass=${hass}
+        .weatherEntity=${weatherEntity}
+        .config=${{
+          ...baseConfig,
+          current: {
+            show_attributes: ["humidity", "pressure", "wind_speed"],
+            ...(layout ? { attributes_layout: layout } : {}),
+          },
+        }}
+      ></wfc-current-weather>`
+    );
+
+    await el.updateComplete;
+
+    const attrEl = el.querySelector("wfc-current-weather-attributes");
+    expect(attrEl).not.toBeNull();
+    return attrEl!;
+  };
+
+  it("applies the compact grid class when attributes_layout is compact", async () => {
+    const attrEl = await renderAttributes("compact");
+
+    const container = attrEl.querySelector(".wfc-current-attributes");
+    expect(container?.classList.contains("wfc-compact")).toBe(true);
+  });
+
+  it("does not apply the compact class by default", async () => {
+    const attrEl = await renderAttributes();
+
+    const container = attrEl.querySelector(".wfc-current-attributes");
+    expect(container).not.toBeNull();
+    expect(container?.classList.contains("wfc-compact")).toBe(false);
+  });
+
+  it("does not apply the compact class when attributes_layout is default", async () => {
+    const attrEl = await renderAttributes("default");
+
+    const container = attrEl.querySelector(".wfc-current-attributes");
+    expect(container?.classList.contains("wfc-compact")).toBe(false);
+  });
+
+  it("drops the visible labels but keeps the values in compact layout", async () => {
+    const attrEl = await renderAttributes("compact");
+
+    expect(
+      attrEl.querySelectorAll(".wfc-current-attribute-name").length
+    ).toBe(0);
+    expect(
+      attrEl.querySelectorAll(".wfc-current-attribute-value").length
+    ).toBe(3);
+  });
+
+  it("exposes the label as a title on each chip for accessibility", async () => {
+    const attrEl = await renderAttributes("compact");
+
+    const titles = Array.from(
+      attrEl.querySelectorAll(".wfc-current-attribute")
+    ).map((node) => node.getAttribute("title"));
+
+    expect(titles).toEqual(["Humidity", "Pressure", "Wind speed"]);
+  });
+
+  it("keeps labels and sets no title in the default layout", async () => {
+    const attrEl = await renderAttributes("default");
+
+    const labels = Array.from(
+      attrEl.querySelectorAll(".wfc-current-attribute-name")
+    ).map((node) => node.textContent?.trim());
+    expect(labels).toEqual(["Humidity", "Pressure", "Wind speed"]);
+
+    expect(attrEl.querySelector(".wfc-current-attribute[title]")).toBeNull();
+  });
+});
+
 describe("secondary_info_attribute", () => {
   let hass: ExtendedHomeAssistant;
   let weatherEntity: WeatherEntity;

--- a/test/current-weather-attributes.test.ts
+++ b/test/current-weather-attributes.test.ts
@@ -295,17 +295,34 @@ describe("compact attributes layout", () => {
     ).toBe(3);
   });
 
-  it("exposes the label as a title on each chip for accessibility", async () => {
+  it("exposes an accessible name and tooltip on each compact chip", async () => {
     const attrEl = await renderAttributes("compact");
-
-    const titles = Array.from(
+    const chips = Array.from(
       attrEl.querySelectorAll(".wfc-current-attribute")
-    ).map((node) => node.getAttribute("title"));
+    );
 
-    expect(titles).toEqual(["Humidity", "Pressure", "Wind speed"]);
+    // role="img" + aria-label make each chip announce as one named unit
+    // ("Humidity, 40 %") rather than a bare value, which title alone cannot
+    // reliably guarantee across screen readers.
+    expect(chips.map((c) => c.getAttribute("role"))).toEqual([
+      "img",
+      "img",
+      "img",
+    ]);
+    expect(chips.map((c) => c.getAttribute("aria-label"))).toEqual([
+      "Humidity, 40 %",
+      "Pressure, 1000 hPa",
+      "Wind speed, 5 m/s",
+    ]);
+    // title stays as a hover tooltip for sighted users (labels are hidden).
+    expect(chips.map((c) => c.getAttribute("title"))).toEqual([
+      "Humidity",
+      "Pressure",
+      "Wind speed",
+    ]);
   });
 
-  it("keeps labels and sets no title in the default layout", async () => {
+  it("keeps labels and sets no compact a11y attributes in the default layout", async () => {
     const attrEl = await renderAttributes("default");
 
     const labels = Array.from(
@@ -313,6 +330,10 @@ describe("compact attributes layout", () => {
     ).map((node) => node.textContent?.trim());
     expect(labels).toEqual(["Humidity", "Pressure", "Wind speed"]);
 
+    expect(attrEl.querySelector(".wfc-current-attribute[role]")).toBeNull();
+    expect(
+      attrEl.querySelector(".wfc-current-attribute[aria-label]")
+    ).toBeNull();
     expect(attrEl.querySelector(".wfc-current-attribute[title]")).toBeNull();
   });
 });

--- a/test/weather-forecast-card-editor.test.ts
+++ b/test/weather-forecast-card-editor.test.ts
@@ -143,6 +143,18 @@ describe("denormalizeConfig", () => {
       ...CURRENT_WEATHER_ATTRIBUTES,
     ]);
   });
+
+  it("flattens current.attributes_layout onto the form", () => {
+    const form = denormalizeConfig({
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      current: {
+        show_attributes: ["humidity"],
+        attributes_layout: "compact",
+      },
+    });
+    expect(form["current.attributes_layout"]).toBe("compact");
+  });
 });
 
 describe("buildShowAttributes", () => {


### PR DESCRIPTION
Closes #96

## Summary

Adds an optional compact layout for the current-weather attributes. The default full-width vertical list gets tall with several attributes; compact renders them as a fixed two-column grid of icon + value chips.

Opt in via the new `current.attributes_layout` option:

```yaml
current:
  attributes_layout: compact   # "default" (unchanged) | "compact"
  show_attributes:
    - humidity
    - pressure
    - wind_speed
    - visibility
```

## Layout

- Fixed **two-column** grid driven by CSS grid on `.wfc-current-attributes.wfc-compact`.
- Left column reads `icon → value`; the **right column is mirrored** (`nth-child(even)` → `row-reverse`, value right-aligned) so icons sit flush against both card edges.
- Chips are **icon + value only** — the label is dropped visually but kept as a `title` tooltip for hover and screen readers.
- Values line up down each column; reflow is column-based so numbers changing width don't shift the layout.

## Config API

`current.attributes_layout` is a string enum (`default` | `compact`), consistent with the card's other layout options (`forecast.mode`, `default_forecast`) rather than a one-off boolean. A `"default"` selection is not written to config.

## Editor

A **Default / Compact** dropdown in the current-weather section. Round-trips through the existing `denormalizeConfig` / `_valueChanged` normalization (a plain `current.*` scalar).

## Tests

- Compact rendering: grid class applied only when compact, labels dropped, values kept, label exposed as `title`, default layout unchanged (`test/current-weather-attributes.test.ts`).
- Editor: `current.attributes_layout` flattened onto the form by `denormalizeConfig` (`test/weather-forecast-card-editor.test.ts`).
- Full suite: 431 pass. Lint and build clean. Verified visually in the demo across widths.

## Docs

`current.attributes_layout` added to the Current Object table with a compact config example.