### PR TITLE
Feat/historical weather scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,32 @@ current:
 | `use_color_thresholds`    | boolean | `true`                          | Replaces solid temperature lines with a gradient based on actual values when using forecast chart mode. Colors transition at fixed intervals: -10° (Cold), 0° (Freezing), 8° (Chilly), 18° (Mild), 26° (Warm), and 34° (Hot). These thresholds are specified in degrees Celsius (°C). |
 | `show_attribute_selector` | boolean | `false`                         | Displays a settings icon in the top-right corner of the chart for quick access to the attribute selector. The attribute selector is also accessible via hold action by default. See [Chart Attribute Selector](#chart-attribute-selector).                                            |
 | `default_chart_attribute` | string  | `temperature_and_precipitation` | The weather attribute to display by default in chart mode. See [Chart Attribute Selector](#chart-attribute-selector) for available values.                                                                                                                                            |
+| `show_history`            | boolean | `false`                         | Loads observed hourly weather from Home Assistant Recorder before the hourly forecast. The first 24 hours load initially and older pages load while scrolling backwards. Daily and twice-daily views remain forecast-only.                                                            |
+| `history_hours`           | number  | `72`                            | Maximum observed history available while scrolling backwards (`24`-`168` hours). Actual availability depends on Recorder retention and whether the weather entity is recorded.                                                                                                        |
 
 > [!IMPORTANT]
 > **Canvas width limit:** To ensure cross-browser compatibility and prevent rendering issues, the canvas width is capped at 16384 pixels in `chart` mode. At a standard item width of 50px, this supports approximately 320 entries (roughly two weeks of data) which is more than enough to cover reliable weather data from most forecast services. Any data exceeding this limit will be truncated.
+
+### Historical Weather
+
+Historical weather is opt-in and applies to the hourly view in both `simple` and `chart` modes:
+
+```yaml
+type: custom:weather-forecast-card
+entity: weather.home
+default_forecast: hourly
+forecast:
+  show_history: true
+  history_hours: 72
+```
+
+The card loads the most recent 24 hours of observed weather, positions the view at the **Now** boundary, and loads older 24-hour pages as you scroll backwards. Historical entries come from the recorded states and attributes of the configured `weather` entity; they are observations, not archived copies of earlier forecasts.
+
+> [!IMPORTANT]
+> Historical availability is controlled by Home Assistant Recorder. Raw states are retained for `purge_keep_days` (10 days by default), may be excluded by Recorder configuration, and can contain gaps when an integration did not update. The card cannot recover purged or unrecorded data.
+
+> [!NOTE]
+> Daily history is not derived because weather entity snapshots do not reliably provide daily condition summaries or observed precipitation totals. Historical precipitation is therefore omitted unless Home Assistant adds it to the recorded weather entity state.
 
 ### Forecast Actions
 

--- a/src/components/wfc-forecast-chart.ts
+++ b/src/components/wfc-forecast-chart.ts
@@ -129,6 +129,7 @@ export class WfcForecastChart extends LitElement {
   private _chart: Chart | null = null;
   private _temperatureColors: Record<string, string> | null = null;
   private _visibleHistoryCount = 0;
+  private _historyPositionInitialized = false;
   private _nowMarkerPlugin: Plugin = {
     id: "wfc-now-marker",
     afterDraw: (chart) => {
@@ -944,7 +945,6 @@ export class WfcForecastChart extends LitElement {
             "wfc-now-slot": historyCount > 0 && index === historyCount,
           })}
           data-index=${index}
-          data-now-label=${this._nowLabel()}
         >
           <wfc-forecast-header-items
             .hass=${this.hass}
@@ -952,6 +952,8 @@ export class WfcForecastChart extends LitElement {
             .forecastType=${this.forecastType}
             .isTwiceDailyEntity=${this.isTwiceDailyEntity}
             .config=${this.config}
+            .isNow=${historyCount > 0 && index === historyCount}
+            .nowLabel=${this._nowLabel()}
           ></wfc-forecast-header-items>
         </div>
       `);
@@ -1071,9 +1073,6 @@ export class WfcForecastChart extends LitElement {
     const label = xScale.getLabelForValue(dataX);
     const index = this._chart.data.labels?.indexOf(label as string) ?? -1;
     if (index === -1) return;
-    if (this._visibleHistoryCount > 0 && index <= this._visibleHistoryCount) {
-      return;
-    }
 
     const selectedForecast = this.safeForecast[index];
     if (!selectedForecast) return;
@@ -1143,24 +1142,35 @@ export class WfcForecastChart extends LitElement {
       this.forecastType !== "hourly" ||
       this.historyCount <= 0 ||
       !this._scrollContainer ||
+      !Number.isFinite(this.itemWidth) ||
       this.itemWidth <= 0
     ) {
+      if (this.forecastType !== "hourly" || this.historyCount <= 0) {
+        this._historyPositionInitialized = false;
+      }
       return;
     }
 
     const oldHistoryCount =
       (changedProps.get("historyCount") as number | undefined) ?? 0;
     const forecastTypeChanged = changedProps.has("forecastType");
+    const historyCountChanged = changedProps.has("historyCount");
+    const itemWidthChanged = changedProps.has("itemWidth");
+
+    if (!forecastTypeChanged && !historyCountChanged && !itemWidthChanged) {
+      return;
+    }
 
     requestAnimationFrame(() => {
       if (!this._scrollContainer) {
         return;
       }
 
-      if (forecastTypeChanged || oldHistoryCount === 0) {
+      if (!this._historyPositionInitialized || forecastTypeChanged) {
         this._scrollContainer.scrollLeft =
           this._visibleHistoryCount * this.itemWidth;
-      } else if (this.historyCount > oldHistoryCount) {
+        this._historyPositionInitialized = true;
+      } else if (historyCountChanged && this.historyCount > oldHistoryCount) {
         const addedHistory = this.historyCount - oldHistoryCount;
         const oldVisibleHistoryCount = this._getVisibleHistoryCount(
           this.forecast.length - addedHistory,

--- a/src/components/wfc-forecast-chart.ts
+++ b/src/components/wfc-forecast-chart.ts
@@ -43,6 +43,7 @@ import {
   Color,
   ChartDataset,
   ChartOptions,
+  Plugin,
 } from "chart.js";
 
 import "./wfc-forecast-header-items";
@@ -114,7 +115,11 @@ export class WfcForecastChart extends LitElement {
   @property({ attribute: false }) isTwiceDailyEntity = false;
   @property({ attribute: false }) itemWidth: number = 0;
   @property({ attribute: false }) isScrollable = false;
+  @property({ attribute: false }) historyCount = 0;
+  @property({ attribute: false }) historyLoading = false;
+  @property({ attribute: false }) historyHasMore = false;
   @query("canvas") private _canvas?: HTMLCanvasElement;
+  @query(".wfc-scroll-container") private _scrollContainer?: HTMLElement;
 
   @state() private _settingsOpen = false;
   @state() private _selectedAttribute: ChartAttributes =
@@ -123,6 +128,38 @@ export class WfcForecastChart extends LitElement {
   private _lastChartEvent: PointerEvent | null = null;
   private _chart: Chart | null = null;
   private _temperatureColors: Record<string, string> | null = null;
+  private _visibleHistoryCount = 0;
+  private _nowMarkerPlugin: Plugin = {
+    id: "wfc-now-marker",
+    afterDraw: (chart) => {
+      if (this.forecastType !== "hourly" || this._visibleHistoryCount <= 0) {
+        return;
+      }
+
+      const xScale = chart.scales.x;
+      if (!xScale) {
+        return;
+      }
+
+      const x = xScale.getPixelForValue(this._visibleHistoryCount);
+      const { top, bottom } = chart.chartArea;
+      const style = getComputedStyle(this);
+      const color =
+        style.getPropertyValue("--wfc-now-marker-color").trim() ||
+        style.getPropertyValue("--primary-color").trim() ||
+        "#03a9f4";
+
+      chart.ctx.save();
+      chart.ctx.beginPath();
+      chart.ctx.setLineDash([4, 4]);
+      chart.ctx.strokeStyle = color;
+      chart.ctx.lineWidth = 2;
+      chart.ctx.moveTo(x, top);
+      chart.ctx.lineTo(x, bottom);
+      chart.ctx.stroke();
+      chart.ctx.restore();
+    },
+  };
   private _scrollController = new DragScrollController(this, {
     selector: ".wfc-scroll-container",
     childSelector: ".wfc-forecast-slot",
@@ -153,7 +190,8 @@ export class WfcForecastChart extends LitElement {
       changedProps.has("weatherEntity") ||
       changedProps.has("hass") ||
       changedProps.has("forecastType") ||
-      changedProps.has("itemWidth");
+      changedProps.has("itemWidth") ||
+      changedProps.has("historyCount");
 
     if (hasChanged && this.itemWidth > 0 && this.forecast?.length) {
       if (!this._chart) {
@@ -164,13 +202,16 @@ export class WfcForecastChart extends LitElement {
         this.updateChartData(structuralChange);
       }
     }
+
+    this._preserveHistoryScrollPosition(changedProps);
   }
 
   render(): TemplateResult | typeof nothing {
-    const forecast = this.safeForecast;
+    const { forecast, historyCount } = this.safeTimeline;
     if (!forecast?.length || this.itemWidth <= 0) {
       return nothing;
     }
+    this._visibleHistoryCount = historyCount;
 
     const count = forecast.length;
     const gaps = Math.max(count - 1, 0);
@@ -243,6 +284,13 @@ export class WfcForecastChart extends LitElement {
           "is-scrollable": this.isScrollable,
         })}"
       >
+        ${this.historyLoading
+          ? html`<div
+              class="wfc-history-loading"
+              role="status"
+              aria-label="Loading historical weather"
+            ></div>`
+          : nothing}
         <div
           class="wfc-scroll-container"
           style=${styleMap(scrollContainerStyle)}
@@ -254,9 +302,10 @@ export class WfcForecastChart extends LitElement {
           })}
           @pointerdown=${this._onPointerDown}
           @action=${this._onForecastAction}
+          @scroll=${this._onScroll}
         >
           <div class="wfc-forecast-chart-header">
-            ${this.renderHeaderItems(forecast)}
+            ${this.renderHeaderItems(forecast, historyCount)}
           </div>
 
           <div class="wfc-chart-clipper" style=${styleMap(clipperStyle)}>
@@ -272,7 +321,13 @@ export class WfcForecastChart extends LitElement {
           <div class="wfc-forecast-chart-footer">
             ${forecast.map(
               (item, index) => html`
-                <div class="wfc-forecast-slot" data-index=${index}>
+                <div
+                  class=${classMap({
+                    "wfc-forecast-slot": true,
+                    "wfc-history-slot": index < historyCount,
+                  })}
+                  data-index=${index}
+                >
                   <wfc-forecast-info
                     .hass=${this.hass}
                     .weatherEntity=${this.weatherEntity}
@@ -359,7 +414,8 @@ export class WfcForecastChart extends LitElement {
   }
 
   private getChartConfig(): ChartConfiguration {
-    const data = this.safeForecast;
+    const { forecast: data, historyCount } = this.safeTimeline;
+    this._visibleHistoryCount = historyCount;
     const style = getComputedStyle(this);
     const gridColor = style.getPropertyValue("--wfc-chart-grid-color");
     const fontSize = this._getChartFontSize();
@@ -417,17 +473,24 @@ export class WfcForecastChart extends LitElement {
       },
     };
 
+    let config: ChartConfiguration;
     switch (this._selectedAttribute) {
       case "uv_index":
-        return this._getUVIndexConfig(data, style, baseOptions);
+        config = this._getUVIndexConfig(data, style, baseOptions);
+        break;
       case "humidity":
       case "pressure":
       case "apparent_temperature":
-        return this._getSelectedAttributeConfig(data, style, baseOptions);
+        config = this._getSelectedAttributeConfig(data, style, baseOptions);
+        break;
       case "temperature_and_precipitation":
       default:
-        return this._getDefaultWeatherConfig(data, style, baseOptions);
+        config = this._getDefaultWeatherConfig(data, style, baseOptions);
+        break;
     }
+
+    config.plugins = [...(config.plugins ?? []), this._nowMarkerPlugin];
+    return config;
   }
 
   private _getDefaultWeatherConfig(
@@ -849,7 +912,10 @@ export class WfcForecastChart extends LitElement {
     return { minTemp, maxTemp };
   }
 
-  private renderHeaderItems(forecast: ForecastAttribute[]): TemplateResult[] {
+  private renderHeaderItems(
+    forecast: ForecastAttribute[],
+    historyCount: number
+  ): TemplateResult[] {
     const parts: TemplateResult[] = [];
     let currentDay: string | undefined;
 
@@ -871,7 +937,15 @@ export class WfcForecastChart extends LitElement {
       }
 
       parts.push(html`
-        <div class="wfc-forecast-slot" data-index=${index}>
+        <div
+          class=${classMap({
+            "wfc-forecast-slot": true,
+            "wfc-history-slot": index < historyCount,
+            "wfc-now-slot": historyCount > 0 && index === historyCount,
+          })}
+          data-index=${index}
+          data-now-label=${this._nowLabel()}
+        >
           <wfc-forecast-header-items
             .hass=${this.hass}
             .forecast=${item}
@@ -890,24 +964,44 @@ export class WfcForecastChart extends LitElement {
    * Returns a subset of the forecast that fits within the hardware canvas limit.
    * This calculation includes the gap width to ensure exact layout synchronization.
    */
-  private get safeForecast(): ForecastAttribute[] {
-    if (!this.forecast?.length || this.itemWidth <= 0) return [];
+  private get safeTimeline(): {
+    forecast: ForecastAttribute[];
+    historyCount: number;
+  } {
+    if (!this.forecast?.length || this.itemWidth <= 0) {
+      return { forecast: [], historyCount: 0 };
+    }
 
-    const gap = this._getGapValue();
-
-    const maxItems = Math.floor(
-      (MAX_CANVAS_WIDTH + gap) / (this.itemWidth + gap)
-    );
+    const maxItems = this._getMaxTimelineItems();
 
     if (this.forecast.length > maxItems) {
+      const gap = this._getGapValue();
+      const trimHistory = Math.min(
+        this.historyCount,
+        this.forecast.length - maxItems
+      );
       logger.debug(
         `Truncating forecast to ${maxItems} items to stay under ${MAX_CANVAS_WIDTH}px (including ${gap}px gaps).`
       );
 
-      return this.forecast.slice(0, maxItems);
+      return {
+        forecast: this.forecast.slice(trimHistory, trimHistory + maxItems),
+        historyCount: this.historyCount - trimHistory,
+      };
     }
 
-    return this.forecast;
+    return {
+      forecast: this.forecast,
+      historyCount: this.historyCount,
+    };
+  }
+
+  /**
+   * Retained for existing callers and tests that inspect the chart's safe,
+   * canvas-bounded forecast collection.
+   */
+  private get safeForecast(): ForecastAttribute[] {
+    return this.safeTimeline.forecast;
   }
 
   private _getGapValue(): number {
@@ -916,6 +1010,22 @@ export class WfcForecastChart extends LitElement {
     const gapValue = style.getPropertyValue("--forecast-item-gap").trim();
 
     return parseFloat(gapValue) || 0;
+  }
+
+  private _getMaxTimelineItems(): number {
+    const gap = this._getGapValue();
+    return Math.floor((MAX_CANVAS_WIDTH + gap) / (this.itemWidth + gap));
+  }
+
+  private _getVisibleHistoryCount(
+    totalItems: number,
+    historyCount: number
+  ): number {
+    const trimmedHistory = Math.min(
+      historyCount,
+      Math.max(0, totalItems - this._getMaxTimelineItems())
+    );
+    return historyCount - trimmedHistory;
   }
 
   private _onPointerDown(event: PointerEvent) {
@@ -961,6 +1071,9 @@ export class WfcForecastChart extends LitElement {
     const label = xScale.getLabelForValue(dataX);
     const index = this._chart.data.labels?.indexOf(label as string) ?? -1;
     if (index === -1) return;
+    if (this._visibleHistoryCount > 0 && index <= this._visibleHistoryCount) {
+      return;
+    }
 
     const selectedForecast = this.safeForecast[index];
     if (!selectedForecast) return;
@@ -1023,6 +1136,67 @@ export class WfcForecastChart extends LitElement {
           : WEATHER_ATTRIBUTE_ICON_MAP[attr as CurrentWeatherAttributes],
       value: attr,
     }));
+  }
+
+  private _preserveHistoryScrollPosition(changedProps: PropertyValues): void {
+    if (
+      this.forecastType !== "hourly" ||
+      this.historyCount <= 0 ||
+      !this._scrollContainer ||
+      this.itemWidth <= 0
+    ) {
+      return;
+    }
+
+    const oldHistoryCount =
+      (changedProps.get("historyCount") as number | undefined) ?? 0;
+    const forecastTypeChanged = changedProps.has("forecastType");
+
+    requestAnimationFrame(() => {
+      if (!this._scrollContainer) {
+        return;
+      }
+
+      if (forecastTypeChanged || oldHistoryCount === 0) {
+        this._scrollContainer.scrollLeft =
+          this._visibleHistoryCount * this.itemWidth;
+      } else if (this.historyCount > oldHistoryCount) {
+        const addedHistory = this.historyCount - oldHistoryCount;
+        const oldVisibleHistoryCount = this._getVisibleHistoryCount(
+          this.forecast.length - addedHistory,
+          oldHistoryCount
+        );
+        const visibleAdded = this._visibleHistoryCount - oldVisibleHistoryCount;
+        this._scrollContainer.scrollLeft += visibleAdded * this.itemWidth;
+      }
+    });
+  }
+
+  private _onScroll = (): void => {
+    if (
+      !this._scrollContainer ||
+      !this.historyHasMore ||
+      this.historyLoading ||
+      this._visibleHistoryCount === 0
+    ) {
+      return;
+    }
+
+    const threshold = Math.max(this.itemWidth * 1.5, 80);
+    if (this._scrollContainer.scrollLeft <= threshold) {
+      this.dispatchEvent(
+        new CustomEvent("history-load-requested", {
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  };
+
+  private _nowLabel(): string {
+    const key = "ui.common.now";
+    const localized = this.hass.localize(key);
+    return localized && localized !== key ? localized : "Now";
   }
 
   private _onAttributesSelected(e: CustomEvent): void {

--- a/src/components/wfc-forecast-header-items.ts
+++ b/src/components/wfc-forecast-header-items.ts
@@ -30,6 +30,8 @@ export class WfcForecastHeaderItems extends LitElement {
   @property({ attribute: false }) forecastType!: ForecastType;
   @property({ attribute: false }) isTwiceDailyEntity = false;
   @property({ attribute: false }) config!: WeatherForecastCardConfig;
+  @property({ attribute: false }) isNow = false;
+  @property({ attribute: false }) nowLabel = "Now";
 
   private suntimesInfo?: SuntimesInfo | null;
 
@@ -103,6 +105,13 @@ export class WfcForecastHeaderItems extends LitElement {
     const isTwiceDaily =
       this.forecastType === "twice_daily" &&
       this.forecast.is_daytime !== undefined;
+
+    if (this.forecastType === "hourly" && this.isNow) {
+      return {
+        label: this.nowLabel,
+        className: "wfc-now",
+      };
+    }
 
     // For twice_daily forecasts, show weekday + Day/Night indicator
     if (isTwiceDaily) {

--- a/src/components/wfc-forecast-simple.ts
+++ b/src/components/wfc-forecast-simple.ts
@@ -38,6 +38,7 @@ export class WfcForecastSimple extends LitElement {
   @query(".wfc-scroll-container") private _scrollContainer?: HTMLElement;
 
   private _selectedForecastIndex: number | null = null;
+  private _historyPositionInitialized = false;
   private _scrollController = new DragScrollController(this, {
     selector: ".wfc-scroll-container",
     childSelector: ".wfc-forecast-slot",
@@ -54,23 +55,34 @@ export class WfcForecastSimple extends LitElement {
       this.forecastType !== "hourly" ||
       this.historyCount <= 0 ||
       !this._scrollContainer ||
+      !Number.isFinite(this.itemWidth) ||
       this.itemWidth <= 0
     ) {
+      if (this.forecastType !== "hourly" || this.historyCount <= 0) {
+        this._historyPositionInitialized = false;
+      }
       return;
     }
 
     const oldHistoryCount =
       (changedProps.get("historyCount") as number | undefined) ?? 0;
     const forecastTypeChanged = changedProps.has("forecastType");
+    const historyCountChanged = changedProps.has("historyCount");
+    const itemWidthChanged = changedProps.has("itemWidth");
+
+    if (!forecastTypeChanged && !historyCountChanged && !itemWidthChanged) {
+      return;
+    }
 
     requestAnimationFrame(() => {
       if (!this._scrollContainer) {
         return;
       }
 
-      if (forecastTypeChanged || oldHistoryCount === 0) {
+      if (!this._historyPositionInitialized || forecastTypeChanged) {
         this._scrollContainer.scrollLeft = this.historyCount * this.itemWidth;
-      } else if (this.historyCount > oldHistoryCount) {
+        this._historyPositionInitialized = true;
+      } else if (historyCountChanged && this.historyCount > oldHistoryCount) {
         this._scrollContainer.scrollLeft +=
           (this.historyCount - oldHistoryCount) * this.itemWidth;
       }
@@ -116,7 +128,6 @@ export class WfcForecastSimple extends LitElement {
               this.historyCount > 0 && index === this.historyCount,
           })}
           data-index=${index}
-          data-now-label=${this._nowLabel()}
         >
           <wfc-forecast-header-items
             .hass=${this.hass}
@@ -124,6 +135,8 @@ export class WfcForecastSimple extends LitElement {
             .forecastType=${this.forecastType}
             .isTwiceDailyEntity=${this.isTwiceDailyEntity}
             .config=${this.config}
+            .isNow=${this.historyCount > 0 && index === this.historyCount}
+            .nowLabel=${this._nowLabel()}
           ></wfc-forecast-header-items>
           <wfc-forecast-details
             .hass=${this.hass}
@@ -195,12 +208,6 @@ export class WfcForecastSimple extends LitElement {
     const selectedForecast = this.forecast[this._selectedForecastIndex];
 
     if (!selectedForecast) return;
-    if (
-      this.historyCount > 0 &&
-      this._selectedForecastIndex <= this.historyCount
-    ) {
-      return;
-    }
 
     const actionDetails: ForecastActionDetails = {
       selectedForecast,

--- a/src/components/wfc-forecast-simple.ts
+++ b/src/components/wfc-forecast-simple.ts
@@ -1,5 +1,5 @@
-import { html, LitElement, nothing, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { ActionHandlerEvent, fireEvent } from "custom-card-helpers";
 import { actionHandler } from "../hass";
@@ -31,6 +31,11 @@ export class WfcForecastSimple extends LitElement {
   @property({ attribute: false }) isTwiceDailyEntity = false;
   @property({ attribute: false }) config!: WeatherForecastCardConfig;
   @property({ attribute: false }) isScrollable = false;
+  @property({ attribute: false }) itemWidth = 0;
+  @property({ attribute: false }) historyCount = 0;
+  @property({ attribute: false }) historyLoading = false;
+  @property({ attribute: false }) historyHasMore = false;
+  @query(".wfc-scroll-container") private _scrollContainer?: HTMLElement;
 
   private _selectedForecastIndex: number | null = null;
   private _scrollController = new DragScrollController(this, {
@@ -40,6 +45,36 @@ export class WfcForecastSimple extends LitElement {
 
   protected createRenderRoot() {
     return this;
+  }
+
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+
+    if (
+      this.forecastType !== "hourly" ||
+      this.historyCount <= 0 ||
+      !this._scrollContainer ||
+      this.itemWidth <= 0
+    ) {
+      return;
+    }
+
+    const oldHistoryCount =
+      (changedProps.get("historyCount") as number | undefined) ?? 0;
+    const forecastTypeChanged = changedProps.has("forecastType");
+
+    requestAnimationFrame(() => {
+      if (!this._scrollContainer) {
+        return;
+      }
+
+      if (forecastTypeChanged || oldHistoryCount === 0) {
+        this._scrollContainer.scrollLeft = this.historyCount * this.itemWidth;
+      } else if (this.historyCount > oldHistoryCount) {
+        this._scrollContainer.scrollLeft +=
+          (this.historyCount - oldHistoryCount) * this.itemWidth;
+      }
+    });
   }
 
   render(): TemplateResult | typeof nothing {
@@ -73,7 +108,16 @@ export class WfcForecastSimple extends LitElement {
       }
 
       forecastTemplates.push(html`
-        <div class="wfc-forecast-slot" data-index=${index}>
+        <div
+          class=${classMap({
+            "wfc-forecast-slot": true,
+            "wfc-history-slot": index < this.historyCount,
+            "wfc-now-slot":
+              this.historyCount > 0 && index === this.historyCount,
+          })}
+          data-index=${index}
+          data-now-label=${this._nowLabel()}
+        >
           <wfc-forecast-header-items
             .hass=${this.hass}
             .forecast=${forecast}
@@ -104,6 +148,13 @@ export class WfcForecastSimple extends LitElement {
           "is-scrollable": this.isScrollable,
         })}"
       >
+        ${this.historyLoading
+          ? html`<div
+              class="wfc-history-loading"
+              role="status"
+              aria-label="Loading historical weather"
+            ></div>`
+          : nothing}
         <div
           class="wfc-forecast wfc-scroll-container"
           .actionHandler=${actionHandler({
@@ -114,6 +165,7 @@ export class WfcForecastSimple extends LitElement {
           })}
           @action=${this._onForecastAction}
           @pointerdown=${this._onPointerDown}
+          @scroll=${this._onScroll}
         >
           ${forecastTemplates}
         </div>
@@ -143,6 +195,12 @@ export class WfcForecastSimple extends LitElement {
     const selectedForecast = this.forecast[this._selectedForecastIndex];
 
     if (!selectedForecast) return;
+    if (
+      this.historyCount > 0 &&
+      this._selectedForecastIndex <= this.historyCount
+    ) {
+      return;
+    }
 
     const actionDetails: ForecastActionDetails = {
       selectedForecast,
@@ -151,6 +209,33 @@ export class WfcForecastSimple extends LitElement {
 
     fireEvent(this, "action", actionDetails);
   };
+
+  private _onScroll = (): void => {
+    if (
+      !this._scrollContainer ||
+      !this.historyHasMore ||
+      this.historyLoading ||
+      this.historyCount === 0
+    ) {
+      return;
+    }
+
+    const threshold = Math.max(this.itemWidth * 1.5, 80);
+    if (this._scrollContainer.scrollLeft <= threshold) {
+      this.dispatchEvent(
+        new CustomEvent("history-load-requested", {
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  };
+
+  private _nowLabel(): string {
+    const key = "ui.common.now";
+    const localized = this.hass.localize(key);
+    return localized && localized !== key ? localized : "Now";
+  }
 }
 
 declare global {

--- a/src/controllers/weather-history-controller.ts
+++ b/src/controllers/weather-history-controller.ts
@@ -1,0 +1,156 @@
+import type { ExtendedHomeAssistant } from "../types";
+import type { ForecastAttribute } from "../data/weather";
+import {
+  bucketWeatherHistory,
+  fetchWeatherHistory,
+  HistoricalWeatherState,
+} from "../data/weather-history";
+
+const HISTORY_PAGE_HOURS = 24;
+const HOUR_MS = 60 * 60 * 1000;
+
+export interface WeatherHistorySnapshot {
+  forecast: ForecastAttribute[];
+  hasMore: boolean;
+}
+
+/**
+ * Owns bounded, backward-only Recorder paging. The card remains responsible for
+ * Lit state so this class can stay independently testable and discard stale
+ * responses without retaining a component host.
+ */
+export class WeatherHistoryController {
+  private _key?: string;
+  private _generation = 0;
+  private _entityId?: string;
+  private _boundaryTimestamp = 0;
+  private _maximumHours = 0;
+  private _intervalHours = 1;
+  private _oldestRequestedTimestamp = 0;
+  private _states: HistoricalWeatherState[] = [];
+  private _loading = false;
+  private _hasMore = false;
+
+  public get loading(): boolean {
+    return this._loading;
+  }
+
+  public get hasMore(): boolean {
+    return this._hasMore;
+  }
+
+  /**
+   * Returns true when configuration changed and the caller should load the
+   * initial page.
+   */
+  public configure(
+    entityId: string,
+    boundaryTimestamp: number,
+    maximumHours: number,
+    intervalHours: number
+  ): boolean {
+    const key = [entityId, boundaryTimestamp, maximumHours, intervalHours].join(
+      "|"
+    );
+
+    if (key === this._key) {
+      return false;
+    }
+
+    this.reset();
+    this._key = key;
+    this._entityId = entityId;
+    this._boundaryTimestamp = boundaryTimestamp;
+    this._maximumHours = maximumHours;
+    this._intervalHours = intervalHours;
+    this._oldestRequestedTimestamp = boundaryTimestamp;
+    this._hasMore = maximumHours > 0;
+    return true;
+  }
+
+  public reset(): void {
+    this._generation += 1;
+    this._key = undefined;
+    this._entityId = undefined;
+    this._boundaryTimestamp = 0;
+    this._maximumHours = 0;
+    this._intervalHours = 1;
+    this._oldestRequestedTimestamp = 0;
+    this._states = [];
+    this._loading = false;
+    this._hasMore = false;
+  }
+
+  public snapshot(): WeatherHistorySnapshot {
+    return {
+      forecast: bucketWeatherHistory(
+        this._states,
+        this._boundaryTimestamp,
+        this._intervalHours
+      ),
+      hasMore: this._hasMore,
+    };
+  }
+
+  public async loadPreviousPage(
+    hass: ExtendedHomeAssistant
+  ): Promise<WeatherHistorySnapshot | undefined> {
+    if (
+      this._loading ||
+      !this._hasMore ||
+      !this._entityId ||
+      this._boundaryTimestamp <= 0
+    ) {
+      return undefined;
+    }
+
+    const earliestTimestamp =
+      this._boundaryTimestamp - this._maximumHours * HOUR_MS;
+    const endTimestamp = this._oldestRequestedTimestamp;
+    const startTimestamp = Math.max(
+      earliestTimestamp,
+      endTimestamp - HISTORY_PAGE_HOURS * HOUR_MS
+    );
+
+    if (startTimestamp >= endTimestamp) {
+      this._hasMore = false;
+      return this.snapshot();
+    }
+
+    const generation = this._generation;
+    const entityId = this._entityId;
+    this._loading = true;
+
+    try {
+      const states = await fetchWeatherHistory(
+        hass,
+        entityId,
+        new Date(startTimestamp),
+        new Date(endTimestamp)
+      );
+
+      if (generation !== this._generation) {
+        return undefined;
+      }
+
+      const statesByTimestamp = new Map(
+        this._states.map((state) => [state.timestamp, state])
+      );
+      for (const state of states) {
+        statesByTimestamp.set(state.timestamp, state);
+      }
+
+      this._states = [...statesByTimestamp.values()].sort(
+        (left, right) => left.timestamp - right.timestamp
+      );
+      this._oldestRequestedTimestamp = startTimestamp;
+      this._hasMore = states.length > 0 && startTimestamp > earliestTimestamp;
+
+      return this.snapshot();
+    } finally {
+      if (generation === this._generation) {
+        this._loading = false;
+      }
+    }
+  }
+}

--- a/src/data/weather-history.ts
+++ b/src/data/weather-history.ts
@@ -1,0 +1,252 @@
+import type { ForecastAttribute, WeatherEntity } from "./weather";
+import type { ExtendedHomeAssistant } from "../types";
+
+const UNAVAILABLE_STATES = new Set(["unknown", "unavailable"]);
+
+type HistoryAttributes = Record<string, unknown>;
+
+export interface HistoricalWeatherState {
+  state: string;
+  attributes: HistoryAttributes;
+  timestamp: number;
+}
+
+type HistoryResponse = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const asWindBearing = (value: unknown): number | string | undefined =>
+  typeof value === "string" || asFiniteNumber(value) !== undefined
+    ? (value as number | string)
+    : undefined;
+
+const parseCompressedState = (
+  value: unknown,
+  inheritedAttributes: HistoryAttributes
+): HistoricalWeatherState | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const state = value.s;
+  const lastUpdated = value.lu;
+
+  if (
+    typeof state !== "string" ||
+    typeof lastUpdated !== "number" ||
+    !Number.isFinite(lastUpdated)
+  ) {
+    return undefined;
+  }
+
+  const attributes = isRecord(value.a) ? value.a : inheritedAttributes;
+
+  return {
+    state,
+    attributes,
+    timestamp: lastUpdated * 1000,
+  };
+};
+
+const parseFullState = (value: unknown): HistoricalWeatherState | undefined => {
+  if (!isRecord(value) || typeof value.state !== "string") {
+    return undefined;
+  }
+
+  const timestampValue = value.last_updated ?? value.last_changed;
+  if (typeof timestampValue !== "string") {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(timestampValue);
+  if (!Number.isFinite(timestamp)) {
+    return undefined;
+  }
+
+  return {
+    state: value.state,
+    attributes: isRecord(value.attributes) ? value.attributes : {},
+    timestamp,
+  };
+};
+
+/**
+ * Decodes both the current compressed history WebSocket response and the
+ * legacy/full state representation. Missing compressed attributes inherit the
+ * last supplied attribute object, matching Home Assistant's history encoding.
+ */
+export const parseWeatherHistoryResponse = (
+  response: unknown,
+  entityId: string
+): HistoricalWeatherState[] => {
+  if (!isRecord(response)) {
+    return [];
+  }
+
+  const values = response[entityId];
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  const result: HistoricalWeatherState[] = [];
+  let inheritedAttributes: HistoryAttributes = {};
+
+  for (const value of values) {
+    const compressed = parseCompressedState(value, inheritedAttributes);
+    const parsed = compressed ?? parseFullState(value);
+
+    if (!parsed || !Number.isFinite(parsed.timestamp)) {
+      continue;
+    }
+
+    if (
+      isRecord(value) &&
+      isRecord(value.a) &&
+      Object.keys(value.a).length > 0
+    ) {
+      inheritedAttributes = value.a;
+    } else if (
+      isRecord(value) &&
+      isRecord(value.attributes) &&
+      Object.keys(value.attributes).length > 0
+    ) {
+      inheritedAttributes = value.attributes;
+    }
+
+    result.push(parsed);
+  }
+
+  return result.sort((left, right) => left.timestamp - right.timestamp);
+};
+
+export const fetchWeatherHistory = async (
+  hass: ExtendedHomeAssistant,
+  entityId: string,
+  startTime: Date,
+  endTime: Date
+): Promise<HistoricalWeatherState[]> => {
+  const response = await hass.callWS<HistoryResponse>({
+    type: "history/history_during_period",
+    entity_ids: [entityId],
+    start_time: startTime.toISOString(),
+    end_time: endTime.toISOString(),
+    significant_changes_only: false,
+    minimal_response: false,
+    no_attributes: false,
+  });
+
+  return parseWeatherHistoryResponse(response, entityId);
+};
+
+const stateToForecast = (
+  state: HistoricalWeatherState,
+  datetime: string
+): ForecastAttribute | undefined => {
+  if (UNAVAILABLE_STATES.has(state.state)) {
+    return undefined;
+  }
+
+  const temperature = asFiniteNumber(state.attributes.temperature);
+  if (temperature === undefined) {
+    return undefined;
+  }
+
+  return {
+    datetime,
+    temperature,
+    condition: state.state,
+    apparent_temperature: asFiniteNumber(state.attributes.apparent_temperature),
+    humidity: asFiniteNumber(state.attributes.humidity),
+    pressure: asFiniteNumber(state.attributes.pressure),
+    wind_speed: asFiniteNumber(state.attributes.wind_speed),
+    wind_bearing: asWindBearing(state.attributes.wind_bearing),
+    uv_index: asFiniteNumber(state.attributes.uv_index),
+  };
+};
+
+/**
+ * Converts irregular recorder updates into fixed-width slots aligned to the
+ * first forecast timestamp. Absolute intervals preserve repeated/missing local
+ * clock hours across DST and also retain non-whole-hour timezone alignment.
+ */
+export const bucketWeatherHistory = (
+  states: HistoricalWeatherState[],
+  boundaryTimestamp: number,
+  intervalHours = 1
+): ForecastAttribute[] => {
+  const intervalMs = Math.max(1, intervalHours) * 60 * 60 * 1000;
+  const buckets = new Map<
+    number,
+    { timestamp: number; forecast: ForecastAttribute }
+  >();
+
+  for (const state of states) {
+    if (
+      state.timestamp >= boundaryTimestamp ||
+      !Number.isFinite(state.timestamp)
+    ) {
+      continue;
+    }
+
+    const slotTimestamp =
+      boundaryTimestamp +
+      Math.floor((state.timestamp - boundaryTimestamp) / intervalMs) *
+        intervalMs;
+    const forecast = stateToForecast(
+      state,
+      new Date(slotTimestamp).toISOString()
+    );
+
+    if (!forecast) {
+      continue;
+    }
+
+    const existing = buckets.get(slotTimestamp);
+    if (!existing || state.timestamp >= existing.timestamp) {
+      buckets.set(slotTimestamp, {
+        timestamp: state.timestamp,
+        forecast,
+      });
+    }
+  }
+
+  return [...buckets.values()]
+    .sort(
+      (left, right) =>
+        Date.parse(left.forecast.datetime) - Date.parse(right.forecast.datetime)
+    )
+    .map(({ forecast }) => forecast);
+};
+
+export const createCurrentWeatherTimelineEntry = (
+  weatherEntity: WeatherEntity,
+  datetime: string,
+  fallbackTemperature?: number
+): ForecastAttribute | undefined => {
+  const temperature =
+    asFiniteNumber(weatherEntity.attributes.temperature) ?? fallbackTemperature;
+
+  if (temperature === undefined) {
+    return undefined;
+  }
+
+  return {
+    datetime,
+    temperature,
+    condition: UNAVAILABLE_STATES.has(weatherEntity.state)
+      ? undefined
+      : weatherEntity.state,
+    apparent_temperature: asFiniteNumber(
+      weatherEntity.attributes.apparent_temperature
+    ),
+    humidity: asFiniteNumber(weatherEntity.attributes.humidity),
+    pressure: asFiniteNumber(weatherEntity.attributes.pressure),
+    wind_speed: asFiniteNumber(weatherEntity.attributes.wind_speed),
+    wind_bearing: asWindBearing(weatherEntity.attributes.wind_bearing),
+    uv_index: asFiniteNumber(weatherEntity.attributes.uv_index),
+  };
+};

--- a/src/editor/weather-forecast-card-editor.ts
+++ b/src/editor/weather-forecast-card-editor.ts
@@ -394,6 +394,18 @@ export class WeatherForecastCardEditor
         optional: true,
       },
       {
+        name: "forecast.show_history",
+        selector: { boolean: {} },
+        default: false,
+        optional: true,
+      },
+      {
+        name: "forecast.history_hours",
+        optional: true,
+        selector: { number: { min: 24, max: 168 } },
+        default: 72,
+      },
+      {
         name: "forecast.hourly_group_size",
         optional: true,
         selector: { number: { min: 1, max: 4 } },
@@ -849,6 +861,10 @@ export class WeatherForecastCardEditor
         return "Use color thresholds";
       case "forecast.show_attribute_selector":
         return "Show forecast attribute selector";
+      case "forecast.show_history":
+        return "Show hourly weather history";
+      case "forecast.history_hours":
+        return "Maximum hourly history";
       case "forecast.default_chart_attribute":
         return "Default chart forecast attribute";
       case "forecast.hourly_group_size":
@@ -912,6 +928,10 @@ export class WeatherForecastCardEditor
         return "Replaces solid temperature lines with a gradient based on actual values when using forecast chart mode.";
       case "forecast.show_attribute_selector":
         return "When enabled and using chart mode, shows a selector above the forecast to choose which weather attribute to display.";
+      case "forecast.show_history":
+        return "Loads observed weather from Recorder before the hourly forecast. Daily forecasts remain future-only.";
+      case "forecast.history_hours":
+        return "Maximum number of recorded hours to make available while scrolling backwards. Actual availability depends on Recorder retention.";
       case "forecast.default_chart_attribute":
         return "The forecast attribute to visualize by default in chart mode.";
       case "forecast.hourly_group_size":

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,8 @@ export interface WeatherForecastCardForecastConfig {
   extra_attribute?: string;
   mode?: ForecastMode;
   show_sun_times?: boolean;
+  show_history?: boolean;
+  history_hours?: number;
   hourly_group_size?: number;
   hourly_slots?: number;
   daily_slots?: number;

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -79,6 +79,10 @@
     --weather-forecast-card-sunset-color,
     var(--purple-color, #926bc7)
   );
+  --wfc-now-marker-color: var(
+    --weather-forecast-card-now-marker-color,
+    var(--primary-color, #03a9f4)
+  );
   --wfc-day-indicator-color: var(
     --weather-forecast-card-day-indicator-color,
     #056bb8
@@ -350,6 +354,7 @@ wfc-animation-provider.dark[has-clouds] ~ .wfc-container .wfc-current-secondary-
 }
 
 .wfc-mask-container {
+  position: relative;
   width: 100%;
 }
 
@@ -401,6 +406,58 @@ wfc-animation-provider.dark[has-clouds] ~ .wfc-container .wfc-current-secondary-
   max-width: var(--forecast-item-width);
   gap: var(--ha-space-1, 4px);
   scroll-snap-align: start;
+}
+
+.wfc-history-slot {
+  opacity: 0.72;
+}
+
+.wfc-now-slot::before {
+  content: attr(data-now-label);
+  position: absolute;
+  top: 0;
+  left: 4px;
+  z-index: 4;
+  color: var(--wfc-now-marker-color);
+  background: var(--ha-card-background, var(--card-background-color, #fff));
+  font-size: var(--ha-font-size-s, 12px);
+  font-weight: 600;
+  line-height: 20px;
+  padding: 0 3px;
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.wfc-now-slot::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  bottom: 0;
+  left: 0;
+  z-index: 3;
+  border-left: 2px dashed var(--wfc-now-marker-color);
+  pointer-events: none;
+}
+
+.wfc-history-loading {
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  z-index: 6;
+  width: 18px;
+  height: 18px;
+  margin-top: -9px;
+  border: 2px solid var(--divider-color, rgba(127, 127, 127, 0.3));
+  border-top-color: var(--primary-color, #03a9f4);
+  border-radius: 50%;
+  animation: wfc-history-spin 0.8s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes wfc-history-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .wfc-label {

--- a/src/weather-forecast-card.css
+++ b/src/weather-forecast-card.css
@@ -412,20 +412,9 @@ wfc-animation-provider.dark[has-clouds] ~ .wfc-container .wfc-current-secondary-
   opacity: 0.72;
 }
 
-.wfc-now-slot::before {
-  content: attr(data-now-label);
-  position: absolute;
-  top: 0;
-  left: 4px;
-  z-index: 4;
+.wfc-now-slot .wfc-forecast-slot-time-primary {
   color: var(--wfc-now-marker-color);
-  background: var(--ha-card-background, var(--card-background-color, #fff));
-  font-size: var(--ha-font-size-s, 12px);
   font-weight: 600;
-  line-height: 20px;
-  padding: 0 3px;
-  border-radius: 4px;
-  pointer-events: none;
 }
 
 .wfc-now-slot::after {

--- a/src/weather-forecast-card.ts
+++ b/src/weather-forecast-card.ts
@@ -46,6 +46,8 @@ import {
   ForecastAttribute,
   aggregateHourlyForecastData,
 } from "./data/weather";
+import { createCurrentWeatherTimelineEntry } from "./data/weather-history";
+import { WeatherHistoryController } from "./controllers/weather-history-controller";
 import {
   ExtendedHomeAssistant,
   ForecastSubscription,
@@ -78,6 +80,9 @@ const DEFAULT_CONFIG: Partial<WeatherForecastCardConfig> = {
 };
 
 const DISCONNECT_UNSUBSCRIBE_DELAY_MS = 1000;
+const DEFAULT_HISTORY_HOURS = 72;
+const MIN_HISTORY_HOURS = 24;
+const MAX_HISTORY_HOURS = 168;
 
 export class WeatherForecastCard extends LitElement {
   @property({ attribute: false }) public hass?: ExtendedHomeAssistant;
@@ -87,6 +92,9 @@ export class WeatherForecastCard extends LitElement {
   @state() private _currentItemWidth!: number;
   @state() private _currentForecastType: ForecastType = "daily";
   @state() private _isScrollable = false;
+  @state() private _historicalForecastData: ForecastAttribute[] = [];
+  @state() private _historyLoading = false;
+  @state() private _historyHasMore = false;
   @query("ha-card") private _haCard?: HTMLElement;
   @query(".wfc-forecast-container") private _forecastContainer?: HTMLElement;
 
@@ -102,6 +110,7 @@ export class WeatherForecastCard extends LitElement {
 
   private _minForecastItemWidth?: number;
   private _resizeObserver?: ResizeObserver | null = null;
+  private _historyController = new WeatherHistoryController();
 
   static styles = styles as CSSResultGroup;
 
@@ -153,6 +162,17 @@ export class WeatherForecastCard extends LitElement {
     }
 
     if (
+      config.forecast?.history_hours != null &&
+      (!Number.isInteger(config.forecast.history_hours) ||
+        config.forecast.history_hours < MIN_HISTORY_HOURS ||
+        config.forecast.history_hours > MAX_HISTORY_HOURS)
+    ) {
+      throw new Error(
+        `history_hours must be a whole number from ${MIN_HISTORY_HOURS} to ${MAX_HISTORY_HOURS}`
+      );
+    }
+
+    if (
       (config.current?.temperature_precision != null &&
         (config.current.temperature_precision < 0 ||
           config.current.temperature_precision > MAX_TEMPERATURE_PRECISION)) ||
@@ -180,6 +200,7 @@ export class WeatherForecastCard extends LitElement {
 
     this.config = merge({}, DEFAULT_CONFIG, migratedConfig);
     this._currentForecastType = this.config.default_forecast || "daily";
+    this.resetWeatherHistory();
   }
 
   /**
@@ -304,7 +325,10 @@ export class WeatherForecastCard extends LitElement {
       changedProperties.has("_hourlyForecastEvent") ||
       changedProperties.has("_currentForecastType") ||
       changedProperties.has("_currentItemWidth") ||
-      changedProperties.has("_isScrollable")
+      changedProperties.has("_isScrollable") ||
+      changedProperties.has("_historicalForecastData") ||
+      changedProperties.has("_historyLoading") ||
+      changedProperties.has("_historyHasMore")
     );
   }
 
@@ -402,6 +426,10 @@ export class WeatherForecastCard extends LitElement {
                       .isTwiceDailyEntity=${isTwiceDailyEntity}
                       .itemWidth=${this._currentItemWidth}
                       .isScrollable=${this._isScrollable}
+                      .historyCount=${this.getHistoryCount()}
+                      .historyLoading=${this._historyLoading}
+                      .historyHasMore=${this._historyHasMore}
+                      @history-load-requested=${this.loadPreviousHistoryPage}
                     ></wfc-forecast-chart>`
                   : html`<wfc-forecast-simple
                       @action=${this.onForecastAction}
@@ -412,6 +440,11 @@ export class WeatherForecastCard extends LitElement {
                       .forecastType=${this._currentForecastType}
                       .isTwiceDailyEntity=${isTwiceDailyEntity}
                       .isScrollable=${this._isScrollable}
+                      .itemWidth=${this._currentItemWidth}
+                      .historyCount=${this.getHistoryCount()}
+                      .historyLoading=${this._historyLoading}
+                      .historyHasMore=${this._historyHasMore}
+                      @history-load-requested=${this.loadPreviousHistoryPage}
                     ></wfc-forecast-simple>`}
               </div>`}
         </div>
@@ -524,6 +557,8 @@ export class WeatherForecastCard extends LitElement {
         this.config.forecast.hourly_slots
       );
     }
+
+    this.ensureWeatherHistory();
 
     // Auto-switch to available forecast type if current type has no data
     // BUT only if we've received both forecast events (to avoid switching
@@ -870,11 +905,134 @@ export class WeatherForecastCard extends LitElement {
   }
 
   private getCurrentForecast(): ForecastAttribute[] {
-    return (
-      (this._currentForecastType === "hourly"
-        ? this._hourlyForecastData
-        : this._dailyForecastData) || []
+    if (this._currentForecastType !== "hourly") {
+      return this._dailyForecastData || [];
+    }
+
+    const hourlyForecast = this._hourlyForecastData || [];
+    if (
+      !this.config?.forecast?.show_history ||
+      this._historicalForecastData.length === 0 ||
+      hourlyForecast.length === 0 ||
+      !this.hass ||
+      !this.config
+    ) {
+      return hourlyForecast;
+    }
+
+    const boundaryTimestamp = Date.parse(hourlyForecast[0]!.datetime);
+    if (!Number.isFinite(boundaryTimestamp)) {
+      return hourlyForecast;
+    }
+
+    const weatherEntity = this.hass.states[this.config.entity] as WeatherEntity;
+    if (!weatherEntity) {
+      return hourlyForecast;
+    }
+
+    const current = createCurrentWeatherTimelineEntry(
+      weatherEntity,
+      new Date(boundaryTimestamp).toISOString(),
+      hourlyForecast[0]?.temperature
     );
+    const future = hourlyForecast.filter(
+      (forecast) => Date.parse(forecast.datetime) > boundaryTimestamp
+    );
+
+    return current
+      ? [...this._historicalForecastData, current, ...future]
+      : [...this._historicalForecastData, ...hourlyForecast];
+  }
+
+  private getHistoryCount(): number {
+    return this._currentForecastType === "hourly"
+      ? this._historicalForecastData.length
+      : 0;
+  }
+
+  private shouldLoadWeatherHistory(): boolean {
+    return (
+      this.config?.forecast?.show_history === true &&
+      this.config.show_forecast !== false &&
+      this.config.forecast_types !== "daily" &&
+      Boolean(this._hourlyForecastData?.length) &&
+      Boolean(this.hass)
+    );
+  }
+
+  private ensureWeatherHistory(): void {
+    if (!this.shouldLoadWeatherHistory() || !this.config || !this.hass) {
+      this.resetWeatherHistory();
+      return;
+    }
+
+    const boundaryTimestamp = Date.parse(
+      this._hourlyForecastData![0]!.datetime
+    );
+    if (!Number.isFinite(boundaryTimestamp)) {
+      this.resetWeatherHistory();
+      return;
+    }
+
+    const maximumHours =
+      this.config.forecast?.history_hours ?? DEFAULT_HISTORY_HOURS;
+    const intervalHours = Math.max(
+      1,
+      this.config.forecast?.hourly_group_size ?? 1
+    );
+    const changed = this._historyController.configure(
+      this.config.entity,
+      boundaryTimestamp,
+      maximumHours,
+      intervalHours
+    );
+
+    if (!changed) {
+      return;
+    }
+
+    this._historicalForecastData = [];
+    this._historyHasMore = this._historyController.hasMore;
+    void this.loadWeatherHistoryPage();
+  }
+
+  private resetWeatherHistory(): void {
+    this._historyController.reset();
+    this._historicalForecastData = [];
+    this._historyLoading = false;
+    this._historyHasMore = false;
+  }
+
+  private loadPreviousHistoryPage = (): void => {
+    void this.loadWeatherHistoryPage();
+  };
+
+  private async loadWeatherHistoryPage(): Promise<void> {
+    if (!this.hass || this._historyController.loading) {
+      return;
+    }
+
+    this._historyLoading = true;
+    try {
+      const snapshot = await this._historyController.loadPreviousPage(
+        this.hass
+      );
+      if (!snapshot) {
+        return;
+      }
+
+      this._historicalForecastData = snapshot.forecast;
+      this._historyHasMore = snapshot.hasMore;
+
+      if (this._forecastContainer) {
+        this.layoutForecastItems(this._forecastContainer.clientWidth);
+      }
+    } catch (error) {
+      logger.warn("Error loading historical weather:", error);
+      this._historyHasMore = this._historyController.hasMore;
+    } finally {
+      this._historyLoading = this._historyController.loading;
+    }
   }
 
   private layoutForecastItems(containerWidth: number) {

--- a/test/historical-weather-scrolling.test.ts
+++ b/test/historical-weather-scrolling.test.ts
@@ -103,6 +103,74 @@ describe("historical weather scrolling", () => {
     expect(scrollContainer.scrollLeft).toBe(100);
   });
 
+  it("does not return to now after an unrelated Home Assistant update", async () => {
+    const simple = card.shadowRoot!.querySelector(
+      "wfc-forecast-simple"
+    ) as HTMLElement & {
+      itemWidth: number;
+      updateComplete: Promise<boolean>;
+    };
+    const scrollContainer = simple.querySelector(
+      ".wfc-scroll-container"
+    ) as HTMLElement;
+
+    simple.itemWidth = 50;
+    await simple.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    scrollContainer.scrollLeft = 25;
+    card.hass = {
+      ...hass,
+      states: { ...hass.states },
+    };
+    await card.updateComplete;
+    await simple.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(scrollContainer.scrollLeft).toBe(25);
+  });
+
+  it("uses now as the current slot's time label", () => {
+    const nowSlot = card.shadowRoot!.querySelector(".wfc-now-slot");
+
+    expect(
+      nowSlot
+        ?.querySelector(".wfc-forecast-slot-time-primary")
+        ?.textContent?.trim()
+    ).toBe("Now");
+    expect(nowSlot?.hasAttribute("data-now-label")).toBe(false);
+  });
+
+  it("allows a historical slot action to return to daily view", async () => {
+    const simple = card.shadowRoot!.querySelector(
+      "wfc-forecast-simple"
+    ) as HTMLElement & {
+      _onForecastAction: (event: CustomEvent<{ action: "tap" }>) => void;
+    };
+    const historySlot = simple.querySelector(
+      ".wfc-history-slot"
+    ) as HTMLElement;
+
+    historySlot.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        composed: true,
+      })
+    );
+    simple._onForecastAction(
+      new CustomEvent("action", {
+        cancelable: true,
+        detail: { action: "tap" },
+      })
+    );
+    await card.updateComplete;
+
+    expect(card.shadowRoot!.querySelectorAll(".wfc-history-slot")).toHaveLength(
+      0
+    );
+    expect(card.shadowRoot!.querySelector(".wfc-now-slot")).toBeNull();
+  });
+
   it("loads another page when the presentation requests older history", async () => {
     const simple = card.shadowRoot!.querySelector("wfc-forecast-simple");
     expect(simple).not.toBeNull();
@@ -165,13 +233,25 @@ describe("historical weather scrolling", () => {
       "wfc-forecast-chart"
     ) as HTMLElement & {
       itemWidth: number;
+      requestUpdate: () => void;
       updateComplete: Promise<boolean>;
     };
     chart.itemWidth = 55;
     await chart.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
 
     expect(chart.querySelector(".wfc-now-slot")).not.toBeNull();
     expect(chart.querySelectorAll(".wfc-history-slot")).toHaveLength(4);
+
+    const scrollContainer = chart.querySelector(
+      ".wfc-scroll-container"
+    ) as HTMLElement;
+    scrollContainer.scrollLeft = 30;
+    chart.requestUpdate();
+    await chart.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(scrollContainer.scrollLeft).toBe(30);
   });
 
   it("rejects history limits outside the supported range", () => {

--- a/test/historical-weather-scrolling.test.ts
+++ b/test/historical-weather-scrolling.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fixture, waitUntil } from "@open-wc/testing";
+import { html } from "lit";
+import { MockHass } from "./mocks/hass";
+import type {
+  ExtendedHomeAssistant,
+  WeatherForecastCardConfig,
+} from "../src/types";
+import { ForecastMode } from "../src/types";
+import type { WeatherForecastCard } from "../src/weather-forecast-card";
+
+import "../src/index";
+
+describe("historical weather scrolling", () => {
+  let callWS: ReturnType<typeof vi.fn>;
+  let hass: ExtendedHomeAssistant;
+  let card: WeatherForecastCard;
+
+  beforeEach(async () => {
+    const mockHass = new MockHass();
+    hass = mockHass.getHass() as ExtendedHomeAssistant;
+    callWS = vi.fn(
+      async (message: {
+        start_time: string;
+        end_time: string;
+        entity_ids: string[];
+      }) => {
+        const end = Date.parse(message.end_time);
+        return {
+          "weather.demo": [
+            {
+              s: "cloudy",
+              a: {
+                temperature: 11,
+                humidity: 75,
+                pressure: 1009,
+              },
+              lu: (end - 2 * 60 * 60 * 1000) / 1000,
+            },
+            {
+              s: "sunny",
+              a: {
+                temperature: 12,
+                humidity: 65,
+                pressure: 1012,
+              },
+              lu: (end - 60 * 60 * 1000) / 1000,
+            },
+          ],
+        };
+      }
+    );
+    hass.callWS = callWS;
+
+    const config: WeatherForecastCardConfig = {
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      default_forecast: "hourly",
+      forecast: {
+        show_history: true,
+        history_hours: 72,
+        show_sun_times: false,
+      },
+    };
+
+    card = await fixture<WeatherForecastCard>(html`
+      <weather-forecast-card
+        .hass=${hass}
+        .config=${config}
+      ></weather-forecast-card>
+    `);
+    card.setConfig(config);
+    await card.updateComplete;
+    await waitUntil(() => callWS.mock.calls.length === 1);
+    await waitUntil(
+      () => card.shadowRoot!.querySelectorAll(".wfc-history-slot").length === 2
+    );
+  });
+
+  it("loads an initial page and renders observed slots plus the now boundary", () => {
+    expect(callWS).toHaveBeenCalledTimes(1);
+    expect(card.shadowRoot!.querySelectorAll(".wfc-history-slot")).toHaveLength(
+      2
+    );
+    expect(card.shadowRoot!.querySelector(".wfc-now-slot")).not.toBeNull();
+  });
+
+  it("positions the simple timeline at the now boundary", async () => {
+    const simple = card.shadowRoot!.querySelector(
+      "wfc-forecast-simple"
+    ) as HTMLElement & {
+      itemWidth: number;
+      updateComplete: Promise<boolean>;
+    };
+    const scrollContainer = simple.querySelector(
+      ".wfc-scroll-container"
+    ) as HTMLElement;
+
+    simple.itemWidth = 50;
+    await simple.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(scrollContainer.scrollLeft).toBe(100);
+  });
+
+  it("loads another page when the presentation requests older history", async () => {
+    const simple = card.shadowRoot!.querySelector("wfc-forecast-simple");
+    expect(simple).not.toBeNull();
+
+    simple!.dispatchEvent(
+      new CustomEvent("history-load-requested", {
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    await waitUntil(() => callWS.mock.calls.length === 2);
+    expect(callWS).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps daily view forecast-only", async () => {
+    const simple = card.shadowRoot!.querySelector("wfc-forecast-simple");
+    simple!.dispatchEvent(
+      new CustomEvent("action", {
+        bubbles: true,
+        composed: true,
+        detail: { action: "tap" },
+      })
+    );
+
+    await card.updateComplete;
+
+    expect(card.shadowRoot!.querySelectorAll(".wfc-history-slot")).toHaveLength(
+      0
+    );
+    expect(card.shadowRoot!.querySelector(".wfc-now-slot")).toBeNull();
+  });
+
+  it("renders historical slots and a now marker in chart mode", async () => {
+    const config: WeatherForecastCardConfig = {
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      default_forecast: "hourly",
+      forecast: {
+        mode: ForecastMode.Chart,
+        show_history: true,
+        history_hours: 72,
+        show_sun_times: false,
+      },
+    };
+    const chartCard = await fixture<WeatherForecastCard>(html`
+      <weather-forecast-card
+        .hass=${hass}
+        .config=${config}
+      ></weather-forecast-card>
+    `);
+    chartCard.setConfig(config);
+    await chartCard.updateComplete;
+    await waitUntil(
+      () =>
+        chartCard.shadowRoot!.querySelectorAll(".wfc-history-slot").length > 0
+    );
+
+    const chart = chartCard.shadowRoot!.querySelector(
+      "wfc-forecast-chart"
+    ) as HTMLElement & {
+      itemWidth: number;
+      updateComplete: Promise<boolean>;
+    };
+    chart.itemWidth = 55;
+    await chart.updateComplete;
+
+    expect(chart.querySelector(".wfc-now-slot")).not.toBeNull();
+    expect(chart.querySelectorAll(".wfc-history-slot")).toHaveLength(4);
+  });
+
+  it("rejects history limits outside the supported range", () => {
+    expect(() =>
+      card.setConfig({
+        type: "custom:weather-forecast-card",
+        entity: "weather.demo",
+        forecast: {
+          show_history: true,
+          history_hours: 12,
+        },
+      })
+    ).toThrow("history_hours must be a whole number from 24 to 168");
+  });
+});

--- a/test/weather-forecast-card-editor.test.ts
+++ b/test/weather-forecast-card-editor.test.ts
@@ -155,6 +155,20 @@ describe("denormalizeConfig", () => {
     });
     expect(form["current.attributes_layout"]).toBe("compact");
   });
+
+  it("preserves historical weather editor options", () => {
+    const form = denormalizeConfig({
+      type: "custom:weather-forecast-card",
+      entity: "weather.demo",
+      forecast: {
+        show_history: true,
+        history_hours: 96,
+      },
+    });
+
+    expect(form["forecast.show_history"]).toBe(true);
+    expect(form["forecast.history_hours"]).toBe(96);
+  });
 });
 
 describe("buildShowAttributes", () => {

--- a/test/weather-history.test.ts
+++ b/test/weather-history.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  bucketWeatherHistory,
+  createCurrentWeatherTimelineEntry,
+  parseWeatherHistoryResponse,
+} from "../src/data/weather-history";
+import { WeatherHistoryController } from "../src/controllers/weather-history-controller";
+import type { ExtendedHomeAssistant } from "../src/types";
+import type { WeatherEntity } from "../src/data/weather";
+
+describe("weather history data", () => {
+  it("decodes compressed history and inherits omitted attributes", () => {
+    const result = parseWeatherHistoryResponse(
+      {
+        "weather.demo": [
+          {
+            s: "sunny",
+            a: { temperature: 12, humidity: 60 },
+            lu: 1_000,
+          },
+          {
+            s: "cloudy",
+            lu: 2_000,
+          },
+          {
+            s: "rainy",
+            a: { temperature: 10, humidity: 80 },
+            lu: 3_000,
+          },
+        ],
+      },
+      "weather.demo"
+    );
+
+    expect(result).toHaveLength(3);
+    expect(result[1]).toEqual({
+      state: "cloudy",
+      attributes: { temperature: 12, humidity: 60 },
+      timestamp: 2_000_000,
+    });
+  });
+
+  it("accepts full REST-style history states and ignores malformed records", () => {
+    const result = parseWeatherHistoryResponse(
+      {
+        "weather.demo": [
+          {
+            state: "sunny",
+            attributes: { temperature: 15 },
+            last_updated: "2026-07-17T10:00:00.000Z",
+          },
+          { state: "cloudy", attributes: {} },
+          null,
+        ],
+      },
+      "weather.demo"
+    );
+
+    expect(result).toEqual([
+      {
+        state: "sunny",
+        attributes: { temperature: 15 },
+        timestamp: Date.parse("2026-07-17T10:00:00.000Z"),
+      },
+    ]);
+  });
+
+  it("buckets observations against the forecast boundary using the latest update", () => {
+    const boundary = Date.parse("2026-07-17T12:30:00.000Z");
+    const result = bucketWeatherHistory(
+      [
+        {
+          state: "sunny",
+          attributes: { temperature: 10 },
+          timestamp: Date.parse("2026-07-17T10:35:00.000Z"),
+        },
+        {
+          state: "cloudy",
+          attributes: { temperature: 11, humidity: 70 },
+          timestamp: Date.parse("2026-07-17T11:20:00.000Z"),
+        },
+        {
+          state: "rainy",
+          attributes: { temperature: 12, humidity: 80 },
+          timestamp: Date.parse("2026-07-17T11:50:00.000Z"),
+        },
+        {
+          state: "sunny",
+          attributes: { temperature: 99 },
+          timestamp: boundary,
+        },
+      ],
+      boundary
+    );
+
+    expect(result).toEqual([
+      {
+        datetime: "2026-07-17T10:30:00.000Z",
+        temperature: 11,
+        condition: "cloudy",
+        apparent_temperature: undefined,
+        humidity: 70,
+        pressure: undefined,
+        wind_speed: undefined,
+        wind_bearing: undefined,
+        uv_index: undefined,
+      },
+      {
+        datetime: "2026-07-17T11:30:00.000Z",
+        temperature: 12,
+        condition: "rainy",
+        apparent_temperature: undefined,
+        humidity: 80,
+        pressure: undefined,
+        wind_speed: undefined,
+        wind_bearing: undefined,
+        uv_index: undefined,
+      },
+    ]);
+  });
+
+  it("creates a current boundary entry with a forecast temperature fallback", () => {
+    const weatherEntity = {
+      state: "partlycloudy",
+      attributes: {
+        humidity: 65,
+      },
+    } as WeatherEntity;
+
+    expect(
+      createCurrentWeatherTimelineEntry(
+        weatherEntity,
+        "2026-07-17T12:00:00.000Z",
+        17
+      )
+    ).toMatchObject({
+      datetime: "2026-07-17T12:00:00.000Z",
+      temperature: 17,
+      condition: "partlycloudy",
+      humidity: 65,
+    });
+  });
+
+  it("keeps repeated DST clock hours as distinct absolute slots", () => {
+    const boundary = Date.parse("2026-10-25T03:00:00.000Z");
+    const result = bucketWeatherHistory(
+      [
+        {
+          state: "cloudy",
+          attributes: { temperature: 9 },
+          timestamp: Date.parse("2026-10-25T01:30:00.000Z"),
+        },
+        {
+          state: "sunny",
+          attributes: { temperature: 10 },
+          timestamp: Date.parse("2026-10-25T02:30:00.000Z"),
+        },
+      ],
+      boundary
+    );
+
+    expect(result.map((entry) => entry.datetime)).toEqual([
+      "2026-10-25T01:00:00.000Z",
+      "2026-10-25T02:00:00.000Z",
+    ]);
+  });
+});
+
+describe("weather history controller", () => {
+  it("loads bounded 24-hour pages and deduplicates recorder states", async () => {
+    const boundary = Date.parse("2026-07-17T12:00:00.000Z");
+    const callWS = vi.fn(
+      async (message: {
+        start_time: string;
+        end_time: string;
+        entity_ids: string[];
+      }) => {
+        const timestamp = Date.parse(message.end_time) - 60 * 60 * 1000;
+        return {
+          "weather.demo": [
+            {
+              s: "sunny",
+              a: { temperature: 14 },
+              lu: timestamp / 1000,
+            },
+          ],
+        };
+      }
+    );
+    const hass = { callWS } as unknown as ExtendedHomeAssistant;
+    const controller = new WeatherHistoryController();
+
+    expect(controller.configure("weather.demo", boundary, 72, 1)).toBe(true);
+
+    const first = await controller.loadPreviousPage(hass);
+    expect(first?.forecast).toHaveLength(1);
+    expect(first?.hasMore).toBe(true);
+
+    const second = await controller.loadPreviousPage(hass);
+    expect(second?.forecast).toHaveLength(2);
+    expect(callWS).toHaveBeenCalledTimes(2);
+
+    expect(callWS.mock.calls[0]![0]).toMatchObject({
+      type: "history/history_during_period",
+      entity_ids: ["weather.demo"],
+      significant_changes_only: false,
+      minimal_response: false,
+      no_attributes: false,
+    });
+  });
+
+  it("discards a response after configuration is reset", async () => {
+    let resolveRequest: ((value: unknown) => void) | undefined;
+    const hass = {
+      callWS: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveRequest = resolve;
+          })
+      ),
+    } as unknown as ExtendedHomeAssistant;
+    const controller = new WeatherHistoryController();
+    const boundary = Date.parse("2026-07-17T12:00:00.000Z");
+
+    controller.configure("weather.demo", boundary, 72, 1);
+    const request = controller.loadPreviousPage(hass);
+    controller.reset();
+    resolveRequest?.({ "weather.demo": [] });
+
+    await expect(request).resolves.toBeUndefined();
+    expect(controller.snapshot().forecast).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Summary**

Adds optional historical weather to the hourly forecast timeline, allowing users to scroll backwards from the Now boundary to view recorded observations from Home Assistant.

**Changes**

- Adds forecast.show_history to enable historical weather
- Adds forecast.history_hours to configure the maximum history range
- Loads the latest 24 hours initially
- Lazily loads older 24-hour pages while scrolling backwards
- Supports both simple and chart modes
- Keeps daily and twice-daily views forecast-only
- Preserves the visible scroll position when older history is prepended
- Prevents unrelated Home Assistant updates from snapping the timeline back to Now
- Allows forecast actions to work on historical and Now slots
- Handles missing records, deduplication, time zones, and repeated DST hours
- Adds editor configuration, documentation, and tests

**Configuration**

```
type: custom:weather-forecast-card
entity: weather.home
default_forecast: hourly
forecast:
  show_history: true
  history_hours: 72
```

show_history defaults to false. history_hours defaults to 72 and accepts values from 24 to 168 hours.

**Home Assistant integration**

History is loaded through Home Assistant’s history/history_during_period frontend WebSocket API. The displayed entries are recorded weather-entity observations, not archived copies of previous forecasts.

Availability depends on Recorder retention and whether the configured weather entity is included in Recorder. No backend changes are required.

**Verification**

- 448 tests passed
- Lint passed
- Production build passed